### PR TITLE
Fix: Support for Proxmox VE v8.4 compatibility

### DIFF
--- a/build.func
+++ b/build.func
@@ -175,7 +175,7 @@ root_check() {
 
 # This function checks the version of Proxmox Virtual Environment (PVE) and exits if the version is not supported.
 pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-3](\.[0-9]+)*"; then
+  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
     msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
     echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
     echo -e "Exiting..."


### PR DESCRIPTION
Proxmox VE의 최신 버전이 8.4이나, 스크립트에서는 8.3까지만 설치가 가능하도록 되어있어, v8.4.x 환경에서 설치를 시도하면 에러가 발생합니다.

이 PR은 Proxmox VE v8.4와의 호환성을 대응합니다.