### PR TITLE
Enable update option in Proxmox community script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ GShare Manager는 Proxmox 환경에서 Android VM을 효율적으로 관리하�
 
 ## 업데이트
 
-도커 호스트 쉘에서 root계정으로 `update`실행 (아마 안될겁니다)
-안되면 아래 커맨드 직접 실행행
+도커 호스트 쉘에서 root계정으로 `update`실행 또는 설치 스크립트를 다시 실행한 뒤 `Update existing GShare installation`을 선택하면 자동으로 업데이트가 진행됩니다.
+직접 업데이트하려면 아래 커맨드를 실행하세요.
 ```
 cd /opt/gshare-manager
 git pull

--- a/build.func
+++ b/build.func
@@ -1024,11 +1024,20 @@ start() {
   mkdir -p "$LOGDIR"
 
   if command -v pveversion >/dev/null 2>&1; then
-    CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --menu "Choose an action:" \
-      12 58 3 \
-      "1" "Create a new ${APP} LXC" \
-      "2" "Update existing ${APP} installation" \
-      "3" "Exit" --default-item "1" 3>&1 1>&2 2>&3)
+    local has_update_menu=0
+    if declare -f update_script >/dev/null 2>&1; then
+      has_update_menu=1
+      CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --menu "Choose an action:" \
+        12 58 3 \
+        "1" "Create a new ${APP} LXC" \
+        "2" "Update existing ${APP} installation" \
+        "3" "Exit" --default-item "1" 3>&1 1>&2 2>&3)
+    else
+      CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --menu "Choose an action:" \
+        10 58 2 \
+        "1" "Create a new ${APP} LXC" \
+        "2" "Exit" --default-item "1" 3>&1 1>&2 2>&3)
+    fi
     MENU_STATUS=$?
     if [ "$MENU_STATUS" -ne 0 ]; then
       clear
@@ -1048,8 +1057,13 @@ start() {
       return
       ;;
     2)
-      run_update_menu
-      return
+      if [ "$has_update_menu" -eq 1 ]; then
+        run_update_menu
+        return
+      fi
+      clear
+      exit_script
+      exit
       ;;
     3)
       clear

--- a/build.func
+++ b/build.func
@@ -1024,45 +1024,80 @@ start() {
   mkdir -p "$LOGDIR"
 
   if command -v pveversion >/dev/null 2>&1; then
-    if ! (whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --yesno "This will create a New ${APP} LXC. Proceed?" 10 58); then
+    CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --menu "Choose an action:" \
+      12 58 3 \
+      "1" "Create a new ${APP} LXC" \
+      "2" "Update existing ${APP} installation" \
+      "3" "Exit" --default-item "1" 3>&1 1>&2 2>&3)
+    MENU_STATUS=$?
+    if [ "$MENU_STATUS" -ne 0 ]; then
       clear
       exit_script
       exit
     fi
-    SPINNER_PID=""
-    install_script
-  fi
-
-  if ! command -v pveversion >/dev/null 2>&1; then
-    CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
-      "Support/Update functions for ${APP} LXC. Choose an option:" \
-      12 60 3 \
-      "1" "YES (Silent Mode)" \
-      "2" "YES (Verbose Mode)" \
-      "3" "NO (Cancel Update)" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
 
     case "$CHOICE" in
     1)
-      VERB="no"
-      set_std_mode
-      log_message "INFO" "Update started (Silent Mode)"
+      if ! (whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --yesno "This will create a New ${APP} LXC. Proceed?" 10 58); then
+        clear
+        exit_script
+        exit
+      fi
+      SPINNER_PID=""
+      install_script
+      return
       ;;
     2)
-      VERB="yes"
-      set_std_mode
-      log_message "INFO" "Update started (Verbose Mode)"
+      run_update_menu
+      return
       ;;
     3)
       clear
-      log_message "INFO" "Update aborted."
+      exit_script
+      exit
+      ;;
+    *)
+      clear
       exit_script
       exit
       ;;
     esac
-
-    SPINNER_PID=""
-    update_script
   fi
+
+  if ! command -v pveversion >/dev/null 2>&1; then
+    run_update_menu
+  fi
+}
+
+run_update_menu() {
+  CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
+    "Support/Update functions for ${APP} LXC. Choose an option:" \
+    12 60 3 \
+    "1" "YES (Silent Mode)" \
+    "2" "YES (Verbose Mode)" \
+    "3" "NO (Cancel Update)" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
+
+  case "$CHOICE" in
+  1)
+    VERB="no"
+    set_std_mode
+    log_message "INFO" "Update started (Silent Mode)"
+    ;;
+  2)
+    VERB="yes"
+    set_std_mode
+    log_message "INFO" "Update started (Verbose Mode)"
+    ;;
+  3)
+    clear
+    log_message "INFO" "Update aborted."
+    exit_script
+    exit
+    ;;
+  esac
+
+  SPINNER_PID=""
+  update_script
 }
 
 # This function collects user settings and integrates all the collected information.

--- a/build.func
+++ b/build.func
@@ -1084,6 +1084,11 @@ start() {
 }
 
 run_update_menu() {
+  if command -v pveversion >/dev/null 2>&1; then
+    run_host_update
+    return
+  fi
+
   CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
     "Support/Update functions for ${APP} LXC. Choose an option:" \
     12 60 3 \
@@ -1112,6 +1117,143 @@ run_update_menu() {
 
   SPINNER_PID=""
   update_script
+}
+
+run_host_update() {
+  local container_json
+  local container_lines
+  local -a containers
+
+  if ! command -v pct >/dev/null 2>&1; then
+    msg_error "pct command is required on the Proxmox host to run updates."
+    echo -e "\nExiting..."
+    sleep 2
+    exit 1
+  fi
+
+  if ! container_json=$(pvesh get /cluster/resources --type lxc --output-format json 2>/dev/null); then
+    msg_error "Unable to query existing LXC containers from the host."
+    echo -e "\nExiting..."
+    sleep 2
+    exit 1
+  fi
+
+  container_lines=$(CONTAINER_JSON="$container_json" python3 - "$var_tags" "$NSAPP" <<'PY'
+import json
+import os
+import sys
+
+tag = sys.argv[1]
+nsapp = sys.argv[2].strip().lower()
+
+try:
+    data = json.loads(os.environ.get("CONTAINER_JSON", "[]"))
+except json.JSONDecodeError:
+    sys.exit(1)
+
+results = []
+for item in data:
+    if item.get("type") != "lxc":
+        continue
+    vmid = str(item.get("vmid", ""))
+    if not vmid.isdigit():
+        continue
+    name = (item.get("name") or "").strip()
+    name_lower = name.lower()
+    tags = (item.get("tags") or "")
+    tag_set = [entry for entry in tags.split(";") if entry]
+
+    include = False
+    if "community-script" in tag_set:
+        if not tag or tag in tag_set:
+            include = True
+    if nsapp and name_lower == nsapp:
+        include = True
+
+    if include:
+        results.append((int(vmid), vmid, name, tags))
+
+for _, vmid, name, tags in sorted(results, key=lambda row: row[0]):
+    print(f"{vmid}|{name}|{tags}")
+PY
+)
+  local parser_status=$?
+
+  if [ $parser_status -ne 0 ]; then
+    echo -e "${INFO}${HOLD} Unable to auto-detect ${APP} containers automatically; manual selection will be required.${CL}"
+  fi
+
+  if [ $parser_status -eq 0 ] && [ -n "$container_lines" ]; then
+    mapfile -t containers <<<"$container_lines"
+  else
+    containers=()
+  fi
+
+  local selected_ctid=""
+
+  if [ "${#containers[@]}" -eq 0 ]; then
+    if ! selected_ctid=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --inputbox "Enter the CT ID of the ${APP} container" 8 58 "" 3>&1 1>&2 2>&3); then
+      clear
+      exit_script
+      exit
+    fi
+    selected_ctid=$(echo "$selected_ctid" | tr -d '[:space:]')
+  elif [ "${#containers[@]}" -eq 1 ]; then
+    IFS='|' read -r selected_ctid _ <<<"${containers[0]}"
+  else
+    local menu_items=()
+    local entry
+    for entry in "${containers[@]}"; do
+      [ -z "$entry" ] && continue
+      IFS='|' read -r ctid cname ctags <<<"$entry"
+      local desc="${cname:-Unnamed}"
+      if [ -n "$ctags" ]; then
+        desc+=" [${ctags}]"
+      fi
+      menu_items+=("$ctid" "$desc")
+    done
+
+    if ! selected_ctid=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC" --menu "Select the container to update" 16 70 6 "${menu_items[@]}" 3>&1 1>&2 2>&3); then
+      clear
+      exit_script
+      exit
+    fi
+  fi
+
+  if [[ ! "$selected_ctid" =~ ^[0-9]+$ ]]; then
+    msg_error "Invalid CT ID supplied for the update operation."
+    echo -e "\nExiting..."
+    sleep 2
+    exit 1
+  fi
+
+  if ! pct status "$selected_ctid" | grep -q "status: running"; then
+    echo -e "${INFO}${HOLD} Starting container ${selected_ctid} for update...${CL}"
+    if ! pct start "$selected_ctid" >/dev/null 2>&1; then
+      msg_error "Failed to start container ${selected_ctid} before running the update."
+      echo -e "\nExiting..."
+      sleep 2
+      exit 1
+    fi
+    sleep 2
+  fi
+
+  clear
+  echo -e "${INFO}${HOLD} Launching update inside container ${selected_ctid}.${CL}"
+  log_message "INFO" "Delegating update to CT ${selected_ctid}"
+
+  pct exec "$selected_ctid" -- bash -lc "wget -qLO - https://raw.githubusercontent.com/wooooooooooook/gshare-manager/refs/heads/main/lxc_update.sh | bash"
+  local update_status=$?
+
+  if [ $update_status -eq 0 ]; then
+    msg_ok "Update completed for container ${selected_ctid}."
+  else
+    msg_error "Update failed inside container ${selected_ctid}."
+  fi
+
+  (exit $update_status)
+  exit_script
+  exit $update_status
 }
 
 # This function collects user settings and integrates all the collected information.


### PR DESCRIPTION
## Summary
- add an action menu to the community script so Proxmox hosts can choose between installing a new LXC or updating an existing one
- reuse the update menu logic for both host and container environments
- document the new update path in the README

## Testing
- pnpm format && pnpm lint *(fails: No package.json found)*
- pnpm check *(fails: No package.json found)*
- pnpm test *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ee84d4ec832cb373003631a154d5