### PR TITLE
Fix update script build func URL

### DIFF
--- a/lxc_update.sh
+++ b/lxc_update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/wooooooooooook/gshare-manager/refs/heads/main/build.func)
+source <(curl -fsSL https://raw.githubusercontent.com/wooooooooooook/gshare-manager/main/build.func)
 # Copyright (c) 2021-2025 community-scripts ORG
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 


### PR DESCRIPTION
## Summary
- update the LXC update script to download build.func from the correct branch URL
- ensure curl fails fast when the remote file is unavailable

## Testing
- pnpm format && pnpm lint *(fails: No package.json found in repository)*
- pnpm check *(fails: No package.json found in repository)*
- pnpm test *(fails: No package.json found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f33bf6186c832cb814096b244bb433