### PR TITLE
터치 환경에서 폴더명 가로 스크롤 개선

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -820,6 +820,7 @@ function shutdownVM() {
 function updateFolderNameScrolling(root = document) {
     const targetRoot = root && typeof root.querySelectorAll === 'function' ? root : document;
     const elements = targetRoot.querySelectorAll('.folder-name-text');
+    const isTouchDevice = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 
     if (!elements.length) {
         return;
@@ -829,6 +830,13 @@ function updateFolderNameScrolling(root = document) {
         elements.forEach(element => {
             const wrapper = element.closest('.folder-name-wrapper');
             if (!wrapper) {
+                return;
+            }
+
+            if (isTouchDevice) {
+                element.classList.remove('is-scrollable');
+                element.style.removeProperty('--scroll-distance');
+                element.style.removeProperty('transform');
                 return;
             }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,6 +35,23 @@
                                         transform: translateX(calc(-1 * var(--scroll-distance)));
                                 }
                         }
+
+                        @media (hover: none) and (pointer: coarse) {
+                                .folder-name-wrapper {
+                                        overflow-x: auto;
+                                        -webkit-overflow-scrolling: touch;
+                                        scrollbar-width: none;
+                                }
+
+                                .folder-name-wrapper::-webkit-scrollbar {
+                                        display: none;
+                                }
+
+                                .folder-name-text.is-scrollable {
+                                        animation: none;
+                                        transform: none;
+                                }
+                        }
                 </style>
         </head>
 


### PR DESCRIPTION
### Motivation
- 폴더 목록이 길어졌을 때 현재 마키(marquee) 애니메이션이 터치 환경에서 폴더명을 끝까지 보여주지 못하는 문제를 해결하기 위함입니다.
- 터치 디바이스에서는 사용자가 직접 스와이프하여 전체 폴더명을 확인할 수 있는 UX가 필요합니다.

### Description
- `app/templates/index.html`에 터치(코어 포인터) 환경을 위한 `@media (hover: none) and (pointer: coarse)` 스타일을 추가해 `overflow-x: auto` 및 스크롤바 숨김을 설정했습니다.
- 같은 미디어쿼리에서 `.folder-name-text.is-scrollable`의 애니메이션을 비활성화하여 마키 애니메이션 충돌을 방지했습니다.
- `app/static/scripts.js`의 `updateFolderNameScrolling` 함수에 터치 디바이스 감지(`window.matchMedia('(hover: none) and (pointer: coarse)')`) 로직을 추가해 터치 환경에서는 스크롤 계산 및 애니메이션 클래스를 적용하지 않도록 했습니다.

### Testing
- 헤드리스 브라우저(Playwright)를 이용해 변경된 스타일의 시뮬레이션(모바일/터치 환경) 및 스크린샷 생성 자동화가 성공적으로 실행되었습니다.
- 임시로 `python -m http.server`로 프리뷰 파일을 서빙한 후 자동화 스크립트가 페이지에 접근하여 스크린샷을 생성하는 절차가 성공했습니다.
- 저장소에 자동화된 빌드/린트/유닛 테스트가 없어 해당 단계는 실행하지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef2dbaa6c832c9087eaabcdbb12b2)