### PR TITLE
PVE 버전 체크 확장(9.x 허용) 및 README 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GShare Manager는 Proxmox 환경에서 Android VM을 효율적으로 관리하�
 
 ## 사전 준비사항
 
+- Proxmox VE 8.1 이상(9.x 포함)
 - Proxmox에 설치된 Android VM (구글포토, Macrodroid 설치)
 - Proxmox API token, secret 준비, 권한은 androidVM에 대해서만 주면 됩니다. (아래 예시)
 - ![예시](https://github.com/user-attachments/assets/b38d3cdc-65c4-4762-bb57-2dd20b6279ca)

--- a/build.func
+++ b/build.func
@@ -175,7 +175,7 @@ root_check() {
 
 # This function checks the version of Proxmox Virtual Environment (PVE) and exits if the version is not supported.
 pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
+  if ! pveversion | grep -Eq "pve-manager/(8\.[1-9]|9\.[0-9]+)(\.[0-9]+)*"; then
     msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
     echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
     echo -e "Exiting..."


### PR DESCRIPTION
### Motivation
- Proxmox VE 9.x 릴리스에서도 스크립트가 불필요하게 종료되는 것을 방지하기 위해 버전 검증을 확장했습니다.
- 사용자에게 요구되는 PVE 최소 버전을 README에 명확히 안내하기 위함입니다.

### Description
- `pve_check()`의 버전 검사 정규식을 변경하여 `pveversion` 출력에서 PVE 8.1 이상 및 9.x를 허용하도록 수정했습니다.
- 관련 문서인 `README.md`의 `사전 준비사항`에 `Proxmox VE 8.1 이상(9.x 포함)` 항목을 추가했습니다.
- 수정 파일: `build.func`, `README.md`.
- 파일 끝의 줄바꿈 정리(트레일링 뉴라인 유지)를 적용했습니다.

### Testing
- 자동화된 빌드/린트/테스트는 실행하지 않았습니다.
- precommit 단계의 빌드/린트/테스트는 실행되지 않았으며 필요시 별도로 실행을 권장합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef522a598832c96a734c459f2ce06)