### PR TITLE
Add MQTT integration and Home Assistant discovery

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -60,6 +60,20 @@ class GshareConfig:
     ## NFS 공유 경로
     NFS_PATH: Optional[str] = None
 
+    # MQTT 설정
+    ## MQTT 브로커 호스트
+    MQTT_BROKER: str = ''
+    ## MQTT 포트
+    MQTT_PORT: int = 1883
+    ## MQTT 사용자 이름
+    MQTT_USERNAME: str = ''
+    ## MQTT 비밀번호
+    MQTT_PASSWORD: str = ''
+    ## MQTT 토픽 접두사
+    MQTT_TOPIC_PREFIX: str = 'gshare'
+    ## Home Assistant Discovery 접두사
+    HA_DISCOVERY_PREFIX: str = 'homeassistant'
+
     @classmethod
     def load_config(cls) -> 'GshareConfig':
         """설정 파일에서 설정 로드"""
@@ -80,7 +94,7 @@ class GshareConfig:
         # 필수 필드 확인
         required_fields = [
             'proxmox', 'mount', 'smb', 'timezone',
-            'credentials'
+            'credentials', 'mqtt'
         ]
         
         for field in required_fields:
@@ -137,7 +151,13 @@ class GshareConfig:
             'SMB_LINKS_DIR': yaml_config['smb'].get('links_dir', '/mnt/gshare_links'),
             'SMB_PORT': yaml_config['smb'].get('port', 445),
             'TIMEZONE': yaml_config.get('timezone', 'Asia/Seoul'),
-            'LOG_LEVEL': log_level
+            'LOG_LEVEL': log_level,
+            'MQTT_BROKER': yaml_config['mqtt'].get('broker', ''),
+            'MQTT_PORT': yaml_config['mqtt'].get('port', 1883),
+            'MQTT_USERNAME': yaml_config['credentials'].get('mqtt_username', ''),
+            'MQTT_PASSWORD': yaml_config['credentials'].get('mqtt_password', ''),
+            'MQTT_TOPIC_PREFIX': yaml_config['mqtt'].get('topic_prefix', 'gshare'),
+            'HA_DISCOVERY_PREFIX': yaml_config['mqtt'].get('ha_discovery_prefix', 'homeassistant')
         }
 
         # NFS 설정 추가
@@ -166,6 +186,7 @@ class GshareConfig:
                     'smb': {},
                     'credentials': {},
                     'nfs': {},
+                    'mqtt': {},
                     'timezone': 'Asia/Seoul',
                     'log_level': 'INFO'
                 }
@@ -177,6 +198,7 @@ class GshareConfig:
                 'smb': {},
                 'credentials': {},
                 'nfs': {},
+                'mqtt': {},
                 'timezone': 'Asia/Seoul',
                 'log_level': 'INFO'
             }
@@ -214,6 +236,16 @@ class GshareConfig:
         if 'LOG_LEVEL' in config_dict:
             yaml_config['log_level'] = config_dict['LOG_LEVEL']
         
+        # MQTT 설정 업데이트
+        if 'MQTT_BROKER' in config_dict:
+            yaml_config['mqtt']['broker'] = config_dict['MQTT_BROKER']
+        if 'MQTT_PORT' in config_dict:
+            yaml_config['mqtt']['port'] = int(config_dict['MQTT_PORT'])
+        if 'MQTT_TOPIC_PREFIX' in config_dict:
+            yaml_config['mqtt']['topic_prefix'] = config_dict['MQTT_TOPIC_PREFIX']
+        if 'HA_DISCOVERY_PREFIX' in config_dict:
+            yaml_config['mqtt']['ha_discovery_prefix'] = config_dict['HA_DISCOVERY_PREFIX']
+
         # 민감한 정보(자격 증명) 업데이트
         if 'PROXMOX_HOST' in config_dict:
             yaml_config['credentials']['proxmox_host'] = config_dict['PROXMOX_HOST']
@@ -227,6 +259,10 @@ class GshareConfig:
             yaml_config['credentials']['smb_username'] = config_dict['SMB_USERNAME']
         if 'SMB_PASSWORD' in config_dict:
             yaml_config['credentials']['smb_password'] = config_dict['SMB_PASSWORD']
+        if 'MQTT_USERNAME' in config_dict:
+            yaml_config['credentials']['mqtt_username'] = config_dict['MQTT_USERNAME']
+        if 'MQTT_PASSWORD' in config_dict:
+            yaml_config['credentials']['mqtt_password'] = config_dict['MQTT_PASSWORD']
         
         # NFS 설정 저장
         if 'NFS_PATH' in config_dict:
@@ -258,7 +294,7 @@ class GshareConfig:
                     yaml_config['credentials'] = {}
                 
                 # 필요한 항목이 없으면 빈 값 추가
-                for section in ['proxmox', 'mount', 'smb', 'nfs']:
+                for section in ['proxmox', 'mount', 'smb', 'nfs', 'mqtt']:
                     if section not in yaml_config:
                         yaml_config[section] = {}
                 
@@ -275,7 +311,8 @@ class GshareConfig:
             'mount': {'path': '/mnt/gshare', 'folder_size_timeout': 30},
             'smb': {'share_name': 'gshare', 'comment': 'GShare SMB 공유', 'guest_ok': False, 'read_only': True, 'links_dir': '/mnt/gshare_links', 'port': 445},
             'nfs': {'path': ''},
-            'credentials': {'proxmox_host': '', 'token_id': '', 'secret': '', 'shutdown_webhook_url': '', 'smb_username': '', 'smb_password': ''},
+            'mqtt': {'broker': '', 'port': 1883, 'topic_prefix': 'gshare', 'ha_discovery_prefix': 'homeassistant'},
+            'credentials': {'proxmox_host': '', 'token_id': '', 'secret': '', 'shutdown_webhook_url': '', 'smb_username': '', 'smb_password': '', 'mqtt_username': '', 'mqtt_password': ''},
             'timezone': 'Asia/Seoul'
         }
 

--- a/app/mqtt_manager.py
+++ b/app/mqtt_manager.py
@@ -1,0 +1,218 @@
+import logging
+import json
+import threading
+import time
+from typing import Any, Dict, Optional
+import paho.mqtt.client as mqtt  # type: ignore
+from config import GshareConfig  # type: ignore
+from datetime import datetime
+import pytz  # type: ignore
+
+class MQTTManager:
+    def __init__(self, config: GshareConfig):
+        self.config = config
+        self.client: Optional[mqtt.Client] = None
+        self.connected = False
+        self._setup_client()
+
+    def _setup_client(self):
+        if not self.config.MQTT_BROKER:
+            logging.info("MQTT 브로커 설정이 없어 MQTT 기능을 비활성화합니다.")
+            return
+
+        try:
+            # Client ID 생성 (랜덤)
+            client_id = f"gshare_manager_{int(time.time())}"
+            self.client = mqtt.Client(client_id=client_id)
+
+            if self.config.MQTT_USERNAME and self.config.MQTT_PASSWORD:
+                self.client.username_pw_set(self.config.MQTT_USERNAME, self.config.MQTT_PASSWORD)
+
+            self.client.on_connect = self._on_connect
+            self.client.on_disconnect = self._on_disconnect
+
+            # 비동기 연결 시작
+            logging.info(f"MQTT 브로커 연결 시도: {self.config.MQTT_BROKER}:{self.config.MQTT_PORT}")
+            self.client.connect_async(self.config.MQTT_BROKER, self.config.MQTT_PORT, 60)
+            self.client.loop_start()
+
+        except Exception as e:
+            logging.error(f"MQTT 클라이언트 설정 중 오류: {e}")
+            self.client = None
+
+    def _on_connect(self, client, userdata, flags, rc):
+        if rc == 0:
+            logging.info("MQTT 브로커에 연결되었습니다.")
+            self.connected = True
+            self.publish_discovery()
+
+            # Availability 토픽에 online 메시지 전송 (Retained)
+            availability_topic = f"{self.config.MQTT_TOPIC_PREFIX}/status"
+            self.client.publish(availability_topic, "online", retain=True)
+        else:
+            logging.error(f"MQTT 연결 실패, 결과 코드: {rc}")
+            self.connected = False
+
+    def _on_disconnect(self, client, userdata, rc):
+        logging.warning("MQTT 브로커 연결이 끊어졌습니다.")
+        self.connected = False
+
+    def publish_state(self, state: Any):
+        """현재 상태를 MQTT로 발행"""
+        if not self.client or not self.connected:
+            return
+
+        try:
+            topic = f"{self.config.MQTT_TOPIC_PREFIX}/state"
+
+            # State 객체를 딕셔너리로 변환
+            if hasattr(state, 'to_dict'):
+                payload = state.to_dict()
+            else:
+                payload = state
+
+            # monitored_folders는 너무 크거나 복잡할 수 있으므로 개수만 포함하거나 별도 처리
+            if 'monitored_folders' in payload and isinstance(payload['monitored_folders'], dict):
+                payload['watched_folder_count'] = len(payload['monitored_folders'])
+                # 상세 정보는 제거하거나 별도 토픽으로 발행 고려 (여기서는 간단히 제거하지 않음)
+
+            self.client.publish(topic, json.dumps(payload, default=str))
+            # logging.debug(f"MQTT 상태 발행 완료: {topic}")
+
+        except Exception as e:
+            logging.error(f"MQTT 상태 발행 중 오류: {e}")
+
+    def publish_discovery(self):
+        """Home Assistant Discovery 메시지 발행"""
+        if not self.client or not self.connected:
+            return
+
+        try:
+            discovery_prefix = self.config.HA_DISCOVERY_PREFIX
+            device_info = {
+                "identifiers": ["gshare_manager"],
+                "name": "GShare Manager",
+                "manufacturer": "wooooooooooook",
+                "model": "GShare Manager Docker",
+                "sw_version": "1.0.0"
+            }
+
+            base_topic = f"{self.config.MQTT_TOPIC_PREFIX}/state"
+            availability_topic = f"{self.config.MQTT_TOPIC_PREFIX}/status"
+
+            # 센서 정의
+            sensors = [
+                {
+                    "name": "VM Status",
+                    "id": "vm_status",
+                    "type": "binary_sensor",
+                    "device_class": "running",
+                    "value_template": "{{ 'ON' if value_json.vm_running else 'OFF' }}",
+                    "icon": "mdi:server"
+                },
+                {
+                    "name": "SMB Status",
+                    "id": "smb_status",
+                    "type": "binary_sensor",
+                    "device_class": "connectivity",
+                    "value_template": "{{ 'ON' if value_json.smb_running else 'OFF' }}",
+                    "icon": "mdi:folder-network"
+                },
+                {
+                    "name": "NFS Status",
+                    "id": "nfs_status",
+                    "type": "binary_sensor",
+                    "device_class": "connectivity",
+                    "value_template": "{{ 'ON' if value_json.nfs_mounted else 'OFF' }}",
+                    "icon": "mdi:nas"
+                },
+                {
+                    "name": "CPU Usage",
+                    "id": "cpu_usage",
+                    "type": "sensor",
+                    "unit_of_measurement": "%",
+                    "value_template": "{{ value_json.cpu_usage }}",
+                    "icon": "mdi:cpu-64-bit"
+                },
+                {
+                    "name": "Watched Folders Count",
+                    "id": "watched_folders_count",
+                    "type": "sensor",
+                    "value_template": "{{ value_json.watched_folder_count }}",
+                    "icon": "mdi:folder-multiple"
+                },
+                {
+                    "name": "Last Check Time",
+                    "id": "last_check_time",
+                    "type": "sensor",
+                    "device_class": "timestamp",
+                    "value_template": "{{ value_json.last_check_time }}", # ISO 포맷 필요할 수 있음
+                    "icon": "mdi:clock-check"
+                },
+                {
+                    "name": "Last Action",
+                    "id": "last_action",
+                    "type": "sensor",
+                    "value_template": "{{ value_json.last_action }}",
+                    "icon": "mdi:history"
+                },
+                {
+                    "name": "Uptime",
+                    "id": "uptime",
+                    "type": "sensor",
+                    "value_template": "{{ value_json.uptime }}",
+                    "icon": "mdi:timer-outline"
+                },
+                {
+                    "name": "Last Shutdown Time",
+                    "id": "last_shutdown_time",
+                    "type": "sensor",
+                    "device_class": "timestamp",
+                    "value_template": "{{ value_json.last_shutdown_time }}",
+                    "icon": "mdi:clock-end"
+                }
+            ]
+
+            for sensor in sensors:
+                component = sensor["type"]
+                object_id = f"gshare_{sensor['id']}"
+                discovery_topic = f"{discovery_prefix}/{component}/gshare/{sensor['id']}/config"
+
+                payload = {
+                    "name": f"GShare {sensor['name']}",
+                    "unique_id": object_id,
+                    "state_topic": base_topic,
+                    "availability_topic": availability_topic,
+                    "payload_available": "online",
+                    "payload_not_available": "offline",
+                    "device": device_info,
+                    "value_template": sensor["value_template"]
+                }
+
+                if "device_class" in sensor:
+                    payload["device_class"] = sensor["device_class"]
+                if "unit_of_measurement" in sensor:
+                    payload["unit_of_measurement"] = sensor["unit_of_measurement"]
+                if "icon" in sensor:
+                    payload["icon"] = sensor["icon"]
+
+                self.client.publish(discovery_topic, json.dumps(payload), retain=True)
+
+            logging.info("Home Assistant Discovery 메시지 발행 완료")
+
+        except Exception as e:
+            logging.error(f"Discovery 메시지 발행 중 오류: {e}")
+
+    def disconnect(self):
+        if self.client:
+            # 종료 시 offline 메시지 전송
+            try:
+                if self.connected:
+                    availability_topic = f"{self.config.MQTT_TOPIC_PREFIX}/status"
+                    self.client.publish(availability_topic, "offline", retain=True)
+            except:
+                pass
+
+            self.client.loop_stop()
+            self.client.disconnect()
+            logging.info("MQTT 연결 종료")

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -149,6 +149,9 @@
                     <a class="nav-link" id="smb-tab" data-toggle="tab" href="#smb" role="tab">SMB 설정</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" id="mqtt-tab" data-toggle="tab" href="#mqtt" role="tab">MQTT 설정</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" id="other-tab" data-toggle="tab" href="#other" role="tab">기타 설정</a>
                 </li>
             </ul>
@@ -319,6 +322,46 @@
                             <input type="text" class="form-control" id="smb_links_dir" name="SMB_LINKS_DIR" value="{{ form_data.get('SMB_LINKS_DIR', '/mnt/gshare_links') }}">
                         </div>
                         <button type="button" class="btn btn-secondary" onclick="prevTab('monitoring-tab')">이전</button>
+                        <button type="button" class="btn btn-primary btn-next" onclick="nextTab('mqtt-tab')">다음</button>
+                    </div>
+                </div>
+
+                <!-- MQTT 설정 -->
+                <div class="tab-pane fade" id="mqtt" role="tabpanel" aria-labelledby="mqtt-tab">
+                    <div class="form-section">
+                        <h3>MQTT 설정</h3>
+                        <div class="form-group">
+                            <label for="mqtt_broker">브로커 호스트</label>
+                            <input type="text" class="form-control" id="mqtt_broker" name="MQTT_BROKER" placeholder="예: 192.168.1.100" value="{{ form_data.get('MQTT_BROKER', '') }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="mqtt_port">포트</label>
+                            <input type="number" class="form-control" id="mqtt_port" name="MQTT_PORT" value="{{ form_data.get('MQTT_PORT', 1883) }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="mqtt_username">사용자 이름</label>
+                            <input type="text" class="form-control" id="mqtt_username" name="MQTT_USERNAME" value="{{ form_data.get('MQTT_USERNAME', '') }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="mqtt_password">비밀번호</label>
+                            <input type="password" class="form-control" id="mqtt_password" name="MQTT_PASSWORD" value="{{ form_data.get('MQTT_PASSWORD', '') }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="mqtt_topic_prefix">토픽 접두사</label>
+                            <input type="text" class="form-control" id="mqtt_topic_prefix" name="MQTT_TOPIC_PREFIX" value="{{ form_data.get('MQTT_TOPIC_PREFIX', 'gshare') }}">
+                        </div>
+                        <div class="form-group">
+                            <label for="ha_discovery_prefix">Home Assistant Discovery 접두사</label>
+                            <input type="text" class="form-control" id="ha_discovery_prefix" name="HA_DISCOVERY_PREFIX" value="{{ form_data.get('HA_DISCOVERY_PREFIX', 'homeassistant') }}">
+                        </div>
+                        <div class="form-group">
+                            <button type="button" class="btn btn-info" onclick="testMQTT()">
+                                <span id="test-mqtt-spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                연결 테스트
+                            </button>
+                            <div id="mqtt-test-result" class="mt-2" style="display: none;"></div>
+                        </div>
+                        <button type="button" class="btn btn-secondary" onclick="prevTab('smb-tab')">이전</button>
                         <button type="button" class="btn btn-primary btn-next" onclick="nextTab('other-tab')">다음</button>
                     </div>
                 </div>
@@ -345,7 +388,7 @@
                                 <option value="ERROR" {% if form_data.get('LOG_LEVEL') == 'ERROR' %}selected{% endif %}>ERROR</option>
                             </select>
                         </div>
-                        <button type="button" class="btn btn-secondary" onclick="prevTab('smb-tab')">이전</button>
+                        <button type="button" class="btn btn-secondary" onclick="prevTab('mqtt-tab')">이전</button>
                         <button type="submit" class="btn btn-success">설정 완료</button>
                     </div>
                 </div>
@@ -384,7 +427,7 @@
         }
         
         function updateProgressBar(tabId) {
-            const tabs = ['proxmox-tab', 'nfs-tab', 'vm-tab', 'monitoring-tab', 'smb-tab', 'other-tab'];
+            const tabs = ['proxmox-tab', 'nfs-tab', 'vm-tab', 'monitoring-tab', 'smb-tab', 'mqtt-tab', 'other-tab'];
             const currentIndex = tabs.indexOf(tabId);
             const progressPercentage = ((currentIndex + 1) / tabs.length) * 100;
             
@@ -663,6 +706,55 @@
         
         async function testNFS() {
             return await runNfsTest();
+        }
+
+        async function testMQTT() {
+            const broker = document.getElementById('mqtt_broker').value;
+            const port = document.getElementById('mqtt_port').value;
+            const username = document.getElementById('mqtt_username').value;
+            const password = document.getElementById('mqtt_password').value;
+
+            if (!broker) {
+                alert('브로커 호스트를 입력해주세요.');
+                return;
+            }
+
+            const spinner = document.getElementById('test-mqtt-spinner');
+            const resultDiv = document.getElementById('mqtt-test-result');
+            spinner.classList.remove('d-none');
+            resultDiv.style.display = 'none';
+
+            try {
+                const formData = new FormData();
+                formData.append('mqtt_broker', broker);
+                formData.append('mqtt_port', port);
+                formData.append('mqtt_username', username);
+                formData.append('mqtt_password', password);
+
+                const response = await fetch('/test_mqtt', {
+                    method: 'POST',
+                    body: formData
+                });
+
+                const result = await response.json();
+
+                resultDiv.style.display = 'block';
+                resultDiv.className = 'mt-2 alert';
+
+                if (result.status === 'success') {
+                    resultDiv.classList.add('alert-success');
+                } else {
+                    resultDiv.classList.add('alert-danger');
+                }
+
+                resultDiv.textContent = result.message;
+            } catch (error) {
+                resultDiv.style.display = 'block';
+                resultDiv.className = 'mt-2 alert alert-danger';
+                resultDiv.textContent = '테스트 중 오류가 발생했습니다: ' + error.message;
+            } finally {
+                spinner.classList.add('d-none');
+            }
         }
         
         // 탭별 다음 버튼 상태 업데이트

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ markupsafe==2.0.1
 pyyaml==6.0
 flask-socketio==5.3.6
 python-socketio==5.10.0
-python-engineio==4.8.0 
+python-engineio==4.8.0
+paho-mqtt==1.6.1


### PR DESCRIPTION
Implemented MQTT status publishing and Home Assistant discovery configuration.
- Added MQTT configuration fields to `config.yaml` and setup wizard.
- Implemented `MQTTManager` to handle MQTT connection and publishing.
- Integrated MQTT publishing into `GShareManager` monitoring loop.
- Added MQTT settings tab to `landing.html`.
- Added `paho-mqtt` dependency.

---
*PR created automatically by Jules for task [13061610884796545212](https://jules.google.com/task/13061610884796545212) started by @wooooooooooook*