### PR TITLE
Fix KeyError: 'mqtt' when saving settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -203,6 +203,16 @@ class GshareConfig:
                 'log_level': 'INFO'
             }
 
+        # 필수 섹션이 없는 경우 초기화
+        required_sections = ['proxmox', 'mount', 'smb', 'credentials', 'nfs', 'mqtt']
+        for section in required_sections:
+            if section not in yaml_config or yaml_config[section] is None:
+                yaml_config[section] = {}
+
+        if 'proxmox' in yaml_config and yaml_config['proxmox'] is not None:
+            if 'cpu' not in yaml_config['proxmox'] or yaml_config['proxmox']['cpu'] is None:
+                yaml_config['proxmox']['cpu'] = {}
+
         # 일반 설정 업데이트
         if 'NODE_NAME' in config_dict:
             yaml_config['proxmox']['node_name'] = config_dict['NODE_NAME']


### PR DESCRIPTION
The user reported a `KeyError: 'mqtt'` when saving settings. This was caused by `update_yaml_config` assuming the 'mqtt' section existed in the loaded configuration. This change ensures that all required sections are initialized if they are missing or None before attempting to update their values.

---
*PR created automatically by Jules for task [1046143642855841714](https://jules.google.com/task/1046143642855841714) started by @wooooooooooook*