### PR TITLE
Fix NaN date display issue in frontend by improving date parsing logic

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -1,7 +1,27 @@
+// 날짜 파싱 헬퍼 함수
+function parseDate(dateStr) {
+    if (!dateStr || dateStr === '-') return null;
+    try {
+        // 이미 ISO 형식이면 (T와 타임존 포함) 그대로 파싱
+        if (dateStr.includes('T') && (dateStr.includes('+') || dateStr.endsWith('Z'))) {
+            return new Date(dateStr);
+        }
+        // 아니면 "YYYY-MM-DD HH:MM:SS" 형식으로 가정하고 KST(+09:00) 추가
+        return new Date(dateStr.replace(' ', 'T') + '+09:00');
+    } catch (e) {
+        console.error("Date parsing error:", e);
+        return null;
+    }
+}
+
 // get_time_ago 함수
 function get_time_ago(timestamp_str) {
     try {
-        const last_check = new Date(timestamp_str.replace(' ', 'T') + '+09:00');
+        const last_check = parseDate(timestamp_str);
+
+        // 파싱 실패 시 원본 반환
+        if (!last_check || isNaN(last_check.getTime())) return timestamp_str;
+
         const now = new Date();
         const diff = Math.floor((now - last_check) / 1000);
 
@@ -90,7 +110,12 @@ function updateProgressBar() {
     }
 
     const now = new Date();
-    const lastCheckTime = new Date(document.querySelector('.last-check-time .time-string').innerText.replace(' ', 'T') + '+09:00');
+    const timeString = document.querySelector('.last-check-time .time-string').innerText;
+    const lastCheckTime = parseDate(timeString);
+
+    // 파싱 실패 시 함수 종료
+    if (!lastCheckTime || isNaN(lastCheckTime.getTime())) return;
+
     const elapsedTime = (now - lastCheckTime) / 1000;
     const progress = Math.min(100, (elapsedTime / checkInterval) * 100);
     


### PR DESCRIPTION
This PR fixes the issue where date fields were displaying as "NaN일 전" in the UI.

The root cause was that `get_time_ago` and `updateProgressBar` in `app/static/scripts.js` unconditionally appended `+09:00` to date strings, assuming a specific format. When the backend sent ISO 8601 strings (which already include timezone info), this resulted in double timezone offsets (e.g., `+09:00+09:00`), causing `new Date()` to fail and return `Invalid Date`.

Changes:
- Added `parseDate` helper function in `app/static/scripts.js` to intelligently parse dates.
    - If the string is already ISO (contains 'T' and offset), it is parsed directly.
    - If not (e.g., `YYYY-MM-DD HH:MM:SS`), it appends `+09:00` (preserving existing behavior for those formats).
- Updated `get_time_ago` and `updateProgressBar` to use `parseDate`.
- Added defensive checks for `NaN` results from date math.

Verified with a mock server and Playwright script, confirming that dates are now displayed correctly (e.g., "840일 전").

---
*PR created automatically by Jules for task [13585602777457167980](https://jules.google.com/task/13585602777457167980) started by @wooooooooooook*