### PR TITLE
Allow configuring Proxmox API connection timeout

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,8 @@ class GshareConfig:
     NODE_NAME: str
     ## android VM ID
     VM_ID: str
+    ## API 연결 타임아웃(초)
+    PROXMOX_TIMEOUT: int = 5
     ## API 토큰 ID
     TOKEN_ID: str
     ## API 토큰 시크릿
@@ -134,6 +136,7 @@ class GshareConfig:
             'PROXMOX_HOST': yaml_config['credentials'].get('proxmox_host', ''),
             'NODE_NAME': yaml_config['proxmox'].get('node_name', ''),
             'VM_ID': yaml_config['proxmox'].get('vm_id', ''),
+            'PROXMOX_TIMEOUT': yaml_config['proxmox'].get('timeout', 5),
             'TOKEN_ID': yaml_config['credentials'].get('token_id', ''),
             'SECRET': yaml_config['credentials'].get('secret', ''),
             'CPU_THRESHOLD': yaml_config['proxmox']['cpu'].get('threshold', 10.0),
@@ -216,8 +219,10 @@ class GshareConfig:
         # 일반 설정 업데이트
         if 'NODE_NAME' in config_dict:
             yaml_config['proxmox']['node_name'] = config_dict['NODE_NAME']
-        if 'VM_ID' in config_dict:
-            yaml_config['proxmox']['vm_id'] = config_dict['VM_ID']
+        if "VM_ID" in config_dict:
+            yaml_config["proxmox"]["vm_id"] = config_dict["VM_ID"]
+        if "PROXMOX_TIMEOUT" in config_dict:
+            yaml_config["proxmox"]["timeout"] = int(config_dict["PROXMOX_TIMEOUT"])
         if 'CPU_THRESHOLD' in config_dict:
             yaml_config['proxmox']['cpu']['threshold'] = float(config_dict['CPU_THRESHOLD'])
         if 'CHECK_INTERVAL' in config_dict:
@@ -317,7 +322,7 @@ class GshareConfig:
         
         # 템플릿 파일이 없으면 기본 설정 반환
         return {
-            'proxmox': {'node_name': '', 'vm_id': '', 'cpu': {'threshold': 10.0, 'check_interval': 60, 'threshold_count': 3}},
+            'proxmox': {'node_name': '', 'vm_id': '', 'timeout': 5, 'cpu': {'threshold': 10.0, 'check_interval': 60, 'threshold_count': 3}},
             'mount': {'path': '/mnt/gshare', 'folder_size_timeout': 30},
             'smb': {'share_name': 'gshare', 'comment': 'GShare SMB 공유', 'guest_ok': False, 'read_only': True, 'links_dir': '/mnt/gshare_links', 'port': 445},
             'nfs': {'path': ''},

--- a/app/proxmox_api.py
+++ b/app/proxmox_api.py
@@ -22,7 +22,7 @@ class ProxmoxAPI:
         try:
             response = self.session.get(
                 f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/current",
-                timeout=(5, 10)
+                timeout=(self.config.PROXMOX_TIMEOUT, 10)
             )
             response.raise_for_status()
             result = response.json()["data"]["status"]
@@ -36,7 +36,7 @@ class ProxmoxAPI:
         try:
             response = self.session.get(
                 f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/current",
-                timeout=(5, 10)
+                timeout=(self.config.PROXMOX_TIMEOUT, 10)
             )
             response.raise_for_status()
             result = response.json()["data"]["uptime"]
@@ -50,7 +50,7 @@ class ProxmoxAPI:
         try:
             response = self.session.get(
                 f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/current",
-                timeout=(5, 10)
+                timeout=(self.config.PROXMOX_TIMEOUT, 10)
             )
             response.raise_for_status()
             result = response.json()["data"]["cpu"] * 100
@@ -64,7 +64,7 @@ class ProxmoxAPI:
         try:
             response = self.session.post(
                 f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/start",
-                timeout=(5, 10)
+                timeout=(self.config.PROXMOX_TIMEOUT, 10)
             )
             response.raise_for_status()
             logging.debug(f"VM 시작 응답 받음")

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -175,6 +175,11 @@
                             <input type="text" class="form-control" id="vm_id" name="VM_ID" required placeholder="100" value="{{ form_data.get('VM_ID', '') }}">
                         </div>
                         <div class="form-group">
+                            <label for="proxmox_timeout">API 연결 타임아웃 (초)</label>
+                            <input type="number" class="form-control" id="proxmox_timeout" name="PROXMOX_TIMEOUT" value="{{ form_data.get('PROXMOX_TIMEOUT', 5) }}" min="1" required>
+                            <small class="form-text text-muted">기본값: 5초. 네트워크가 느릴 경우 늘려주세요.</small>
+                        </div>
+                        <div class="form-group">
                             <label for="token_id">API 토큰 ID</label>
                             <input type="text" class="form-control" id="token_id" name="TOKEN_ID" required placeholder="user@pam!token" value="{{ form_data.get('TOKEN_ID', '') }}">
                             <small class="form-text text-muted">Proxmox API 토큰 ID를 입력하세요 (예: user@pam!token)</small>
@@ -576,6 +581,7 @@
             const vmId = document.getElementById('vm_id').value;
             const tokenId = document.getElementById('token_id').value;
             const secret = document.getElementById('secret').value;
+            const proxmoxTimeout = document.getElementById('proxmox_timeout').value;
             
             // 값 검증
             if (!proxmoxHost || !nodeName || !vmId || !tokenId || !secret) {
@@ -595,6 +601,7 @@
                 formData.append('vm_id', vmId);
                 formData.append('token_id', tokenId);
                 formData.append('secret', secret);
+                formData.append('proxmox_timeout', proxmoxTimeout);
                 
                 const response = await fetch('/test_proxmox_api', {
                     method: 'POST',

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -322,6 +322,7 @@ class GshareWebServer:
                 'PROXMOX_HOST': form_data.get('PROXMOX_HOST', ''),
                 'NODE_NAME': form_data.get('NODE_NAME', ''),
                 'VM_ID': form_data.get('VM_ID', ''),
+                'PROXMOX_TIMEOUT': form_data.get('PROXMOX_TIMEOUT', 5),
                 'TOKEN_ID': form_data.get('TOKEN_ID', ''),
                 'SECRET': form_data.get('SECRET', ''),
                 'CPU_THRESHOLD': form_data.get('CPU_THRESHOLD', 10),
@@ -768,6 +769,7 @@ class GshareWebServer:
             vm_id = request.form.get('vm_id')
             token_id = request.form.get('token_id')
             secret = request.form.get('secret')
+            proxmox_timeout = int(request.form.get('proxmox_timeout') or 5)
 
             if not all([proxmox_host, node_name, vm_id, token_id, secret]):
                 return jsonify({
@@ -783,15 +785,15 @@ class GshareWebServer:
 
             try:
                 version_response = session.get(
-                    f"{proxmox_host}/version", timeout=(5, 10))
+                    f"{proxmox_host}/version", timeout=(proxmox_timeout, 10))
                 version_response.raise_for_status()
 
                 node_response = session.get(
-                    f"{proxmox_host}/nodes/{node_name}", timeout=(5, 10))
+                    f"{proxmox_host}/nodes/{node_name}", timeout=(proxmox_timeout, 10))
                 node_response.raise_for_status()
 
                 vm_response = session.get(
-                    f"{proxmox_host}/nodes/{node_name}/qemu/{vm_id}/status/current", timeout=(5, 10))
+                    f"{proxmox_host}/nodes/{node_name}/qemu/{vm_id}/status/current", timeout=(proxmox_timeout, 10))
                 vm_response.raise_for_status()
 
                 vm_status = vm_response.json()["data"]["status"]


### PR DESCRIPTION
This change allows users to configure the connection timeout for Proxmox API calls via the web interface. This is useful for environments with slow network connections or unreliable Proxmox servers. The default timeout remains 5 seconds.

---
*PR created automatically by Jules for task [11707215305478396673](https://jules.google.com/task/11707215305478396673) started by @wooooooooooook*