### PR TITLE
Fixed TypeError in GshareConfig by removing default value from PROXMO…

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,7 +13,7 @@ class GshareConfig:
     ## android VM ID
     VM_ID: str
     ## API 연결 타임아웃(초)
-    PROXMOX_TIMEOUT: int = 5
+    PROXMOX_TIMEOUT: int
     ## API 토큰 ID
     TOKEN_ID: str
     ## API 토큰 시크릿


### PR DESCRIPTION
…X_TIMEOUT in dataclass definition.

Also improved configuration loading robustness:
- In `load_config`, use `or default` pattern to handle `None` values safely.
- In `update_yaml_config`, added validation to prevent crashes with empty string inputs.
- Applied these fixes to all numeric fields.