### PR TITLE
Fix Docker build failure by removing redundant `--without dev` flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install poetry
 COPY pyproject.toml .
 
 # Install dependencies
-RUN poetry config virtualenvs.create false     && poetry install --without dev --no-interaction --no-ansi
+RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi
 
 # 디렉토리 생성
 RUN mkdir -p /mnt/gshare /mnt/gshare_links /config /logs


### PR DESCRIPTION
The build was failing because the `poetry install --without dev` command attempted to exclude a `dev` group that does not exist in `pyproject.toml`.

This change removes the `--without dev` flag from the `Dockerfile` to fix the build error. This aligns the Docker build process with the current project dependencies defined in `pyproject.toml`.

Verification:
- Confirmed `pyproject.toml` does not contain a `dev` dependency group.
- Verified `Dockerfile` changes remove the offending flag.
- Attempted to verify the build locally, but encountered Docker Hub rate limits. However, the fix addresses the specific error message "Group(s) not found: dev (via --without)".

---
*PR created automatically by Jules for task [4669611852005869881](https://jules.google.com/task/4669611852005869881) started by @wooooooooooook*