### PR TITLE
Fix Docker build error by adding --no-root to poetry install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install poetry
 COPY pyproject.toml .
 
 # Install dependencies
-RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi
+RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi --no-root
 
 # 디렉토리 생성
 RUN mkdir -p /mnt/gshare /mnt/gshare_links /config /logs


### PR DESCRIPTION
The Docker build was failing with "The current project could not be installed: No file/folder found for package" because `poetry install` attempts to install the project package by default. Since source files are copied *after* the dependency installation step to optimize caching, the project package cannot be installed at this stage.

This change adds the `--no-root` flag to `poetry install`, ensuring that only dependencies are installed, which resolves the build failure and correctly leverages Docker layer caching.

---
*PR created automatically by Jules for task [3146838947857766461](https://jules.google.com/task/3146838947857766461) started by @wooooooooooook*