### PR TITLE
🧹 Remove unused 'threading' import in MQTTManager

### DIFF
--- a/app/mqtt_manager.py
+++ b/app/mqtt_manager.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import threading
 import time
 from typing import Any, Dict, Optional
 import paho.mqtt.client as mqtt  # type: ignore


### PR DESCRIPTION
removed unused import 'threading' from app/mqtt_manager.py which was not used in the file.
This improves code cleanliness and removes a potential source of confusion.
Verified that the file syntax is still valid.

---
*PR created automatically by Jules for task [7732594246144530473](https://jules.google.com/task/7732594246144530473) started by @wooooooooooook*