### PR TITLE
Refactor SMBManager to use SMB_CONF_PATH constant

### DIFF
--- a/app/smb_manager.py
+++ b/app/smb_manager.py
@@ -4,6 +4,8 @@ import subprocess
 import time
 from config import GshareConfig  # type: ignore
 
+SMB_CONF_PATH = '/etc/samba/smb.conf'
+
 
 class SMBManager:
     """SMB 서비스 관리 클래스"""
@@ -61,7 +63,7 @@ class SMBManager:
    log level = 3
 """
             # 기본 설정 저장
-            with open('/etc/samba/smb.conf', 'w') as f:
+            with open(SMB_CONF_PATH, 'w') as f:
                 f.write(base_config)
 
             # 기존 Samba 사용자 존재 여부 확인
@@ -107,7 +109,7 @@ class SMBManager:
         try:
             # SMB 설정 파일 확인 (공유 설정이 있는지 확인)
             try:
-                with open('/etc/samba/smb.conf', 'r') as f:
+                with open(SMB_CONF_PATH, 'r') as f:
                     content = f.read()
                     share_name = self.config.SMB_SHARE_NAME
                     has_share_config = f"[{share_name}]" in content
@@ -173,7 +175,7 @@ class SMBManager:
             share_name = self.config.SMB_SHARE_NAME
 
             # 설정 파일 읽기
-            with open('/etc/samba/smb.conf', 'r') as f:
+            with open(SMB_CONF_PATH, 'r') as f:
                 lines = f.readlines()
 
             # 빈 줄 제거
@@ -204,7 +206,7 @@ class SMBManager:
             final_lines = global_section_lines + [share_config]
 
             # 설정 파일 저장
-            with open('/etc/samba/smb.conf', 'w') as f:
+            with open(SMB_CONF_PATH, 'w') as f:
                 f.writelines([line for line in final_lines if line.strip()])
 
             logging.debug(
@@ -254,7 +256,7 @@ class SMBManager:
         """모든 SMB 공유 비활성화"""
         try:
             # 설정 파일 읽기
-            with open('/etc/samba/smb.conf', 'r') as f:
+            with open(SMB_CONF_PATH, 'r') as f:
                 lines = f.readlines()
 
             # [global] 섹션만 유지
@@ -265,7 +267,7 @@ class SMBManager:
                 new_lines.append(line)
 
             # 설정 파일 저장
-            with open('/etc/samba/smb.conf', 'w') as f:
+            with open(SMB_CONF_PATH, 'w') as f:
                 f.writelines([line for line in new_lines if line.strip()])
 
             # Samba 서비스 중지

--- a/tests/test_smb_manager.py
+++ b/tests/test_smb_manager.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+import sys
+import os
+
+# Add app directory to sys.path
+sys.path.append(os.path.join(os.getcwd(), 'app'))
+
+# Mock yaml before importing config
+sys.modules['yaml'] = MagicMock()
+
+from smb_manager import SMBManager
+
+class TestSMBManager(unittest.TestCase):
+    def setUp(self):
+        self.mock_config = MagicMock()
+        self.mock_config.SMB_LINKS_DIR = '/tmp/links'
+        self.mock_config.SMB_PORT = 445
+        self.mock_config.SMB_USERNAME = 'user'
+        self.mock_config.SMB_PASSWORD = 'password'
+        self.mock_config.SMB_SHARE_NAME = 'share'
+        self.mock_config.SMB_COMMENT = 'comment'
+        self.mock_config.SMB_GUEST_OK = False
+        self.mock_config.MOUNT_PATH = '/mnt/data'
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('subprocess.run')
+    @patch('os.makedirs')
+    @patch('os.chmod')
+    @patch('os.path.exists')
+    def test_init_smb_config(self, mock_exists, mock_chmod, mock_makedirs, mock_run, mock_file):
+        mock_run.return_value.returncode = 0
+        mock_exists.return_value = False
+
+        with patch.object(SMBManager, '_set_smb_user_ownership'),              patch.object(SMBManager, '_set_links_directory_permissions'),              patch.object(SMBManager, 'cleanup_all_symlinks'):
+
+            manager = SMBManager(self.mock_config, 1000, 1000)
+
+            # Check if open was called with the expected path
+            calls = mock_file.call_args_list
+            smb_conf_calls = [c for c in calls if c[0][0] == '/etc/samba/smb.conf']
+            self.assertTrue(len(smb_conf_calls) > 0, "Should have opened /etc/samba/smb.conf")
+
+    @patch('builtins.open', new_callable=mock_open, read_data='[share]\npath=/tmp')
+    def test_check_smb_status(self, mock_file):
+        with patch.object(SMBManager, '__init__', return_value=None):
+            manager = SMBManager(self.mock_config, 1000, 1000)
+            manager.config = self.mock_config
+
+            manager.check_smb_status()
+
+            mock_file.assert_called_with('/etc/samba/smb.conf', 'r')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactor `app/smb_manager.py` to replace hardcoded `'/etc/samba/smb.conf'` path with a module-level constant `SMB_CONF_PATH`.
Added unit tests in `tests/test_smb_manager.py` to verify functionality.

Verification:
- Ran `tests/test_smb_manager.py` and confirmed all tests pass.
- Verified that all 6 occurrences of the hardcoded path were replaced.


---
*PR created automatically by Jules for task [7875998337157473635](https://jules.google.com/task/7875998337157473635) started by @wooooooooooook*