### PR TITLE
🧹 Refactor ProxmoxAPI to use centralized timeout

### DIFF
--- a/app/proxmox_api.py
+++ b/app/proxmox_api.py
@@ -12,6 +12,7 @@ class ProxmoxAPI:
         self.config = config
         self.session = requests.Session()
         self.session.verify = False
+        self.timeout = (self.config.PROXMOX_TIMEOUT, 10)
 
         # 재시도 로직 설정 (총 3회, 1초 대기)
         try:
@@ -56,7 +57,7 @@ class ProxmoxAPI:
 
         response = self.session.get(
             f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/current",
-            timeout=(self.config.PROXMOX_TIMEOUT, 10)
+            timeout=self.timeout
         )
         response.raise_for_status()
         data = response.json()["data"]
@@ -99,7 +100,7 @@ class ProxmoxAPI:
         try:
             response = self.session.post(
                 f"{self.config.PROXMOX_HOST}/nodes/{self.config.NODE_NAME}/qemu/{self.config.VM_ID}/status/start",
-                timeout=(self.config.PROXMOX_TIMEOUT, 10)
+                timeout=self.timeout
             )
             response.raise_for_status()
             logging.debug(f"VM 시작 응답 받음")


### PR DESCRIPTION
Refactored `ProxmoxAPI` to use a centralized `self.timeout` attribute initialized in `__init__`, replacing hardcoded `(timeout, 10)` tuples in `_get_vm_status_data` and `start_vm`. This improves maintainability and consistency.

🎯 **What:**
- Added `self.timeout = (self.config.PROXMOX_TIMEOUT, 10)` to `ProxmoxAPI.__init__`.
- Updated `_get_vm_status_data` to use `self.timeout`.
- Updated `start_vm` to use `self.timeout`.

💡 **Why:**
- To remove duplicated hardcoded timeout values and ensure `PROXMOX_TIMEOUT` is consistently applied.

✅ **Verification:**
- Created a verification script mocking `requests.Session` and `GshareConfig`.
- Verified that `timeout` argument is correctly passed as `(5, 10)` (assuming config timeout is 5) to `requests.get` and `requests.post`.
- Verified no regression in method calls.

✨ **Result:**
- Cleaner, more maintainable code with centralized timeout configuration.

---
*PR created automatically by Jules for task [2576192102820601589](https://jules.google.com/task/2576192102820601589) started by @wooooooooooook*