### PR TITLE
🧹 refactor: Centralize hardcoded configuration and log paths

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,16 @@ import os
 import yaml
 from typing import Dict, Any, Optional, List
 
+# 경로 관련 상수
+CONFIG_DIR = '/config'
+LOG_DIR = '/logs'
+CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yaml')
+TEMPLATE_PATH = os.path.join(CONFIG_DIR, 'config.yaml.template')
+INIT_FLAG_PATH = os.path.join(CONFIG_DIR, '.init_complete')
+RESTART_FLAG_PATH = os.path.join(CONFIG_DIR, '.restart_in_progress')
+LAST_SHUTDOWN_PATH = os.path.join(CONFIG_DIR, '.last_shutdown')
+LOG_FILE_PATH = os.path.join(LOG_DIR, 'gshare_manager.log')
+
 @dataclass
 class GshareConfig:
     # Proxmox android 사용량 감시
@@ -90,7 +100,7 @@ class GshareConfig:
     def load_config(cls) -> 'GshareConfig':
         """설정 파일에서 설정 로드"""
         # Docker 환경을 가정하고 설정 파일 경로 고정
-        config_path = '/config/config.yaml'
+        config_path = CONFIG_PATH
         
         try:
             if os.path.exists(config_path):
@@ -185,7 +195,7 @@ class GshareConfig:
     def update_yaml_config(config_dict: Dict[str, Any]) -> None:
         """YAML 설정 파일 업데이트"""
         # Docker 환경을 가정하고 설정 파일 경로 고정
-        yaml_path = '/config/config.yaml'
+        yaml_path = CONFIG_PATH
         
         try:
             if os.path.exists(yaml_path):
@@ -311,7 +321,7 @@ class GshareConfig:
     @staticmethod
     def load_template_config() -> Dict[str, Any]:
         """템플릿 설정 파일 로드"""
-        template_path = '/config/config.yaml.template'
+        template_path = TEMPLATE_PATH
         
         try:
             if os.path.exists(template_path):

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,8 @@ import os
 import threading
 import sys
 import atexit
-from config import GshareConfig  # type: ignore
+from config import (GshareConfig, CONFIG_PATH, INIT_FLAG_PATH,
+                    LAST_SHUTDOWN_PATH, LOG_DIR, LOG_FILE_PATH)  # type: ignore
 from proxmox_api import ProxmoxAPI
 from web_server import GshareWebServer
 from smb_manager import SMBManager
@@ -419,7 +420,7 @@ class GShareManager:
     def _load_last_shutdown_time(self) -> float:
         """VM 마지막 종료 시간을 로드 (UTC 기준)"""
         try:
-            shutdown_file_path = '/config/.last_shutdown'
+            shutdown_file_path = LAST_SHUTDOWN_PATH
             if os.path.exists(shutdown_file_path):
                 with open(shutdown_file_path, 'r') as f:
                     return float(f.read().strip())
@@ -749,7 +750,7 @@ class GShareManager:
         try:
             # UTC 기준 현재 시간
             current_time = datetime.now(pytz.UTC).timestamp()
-            shutdown_file_path = '/config/.last_shutdown'
+            shutdown_file_path = LAST_SHUTDOWN_PATH
             with open(shutdown_file_path, 'w') as f:
                 f.write(str(current_time))
             self.last_shutdown_time = current_time
@@ -766,7 +767,7 @@ class GShareManager:
 def setup_logging():
     """기본 로깅 설정을 초기화"""
     # config.yaml에서 로그 레벨 확인
-    yaml_path = '/config/config.yaml'
+    yaml_path = CONFIG_PATH
     log_level = 'INFO'  # 기본값
 
     try:
@@ -786,9 +787,9 @@ def setup_logging():
     os.environ['LOG_LEVEL'] = log_level
 
     # 로그 디렉토리 확인 및 생성
-    log_dir = '/logs'
+    log_dir = LOG_DIR
     os.makedirs(log_dir, exist_ok=True)
-    log_file = os.path.join(log_dir, 'gshare_manager.log')
+    log_file = LOG_FILE_PATH
 
     # 로거 및 포맷터 설정
     formatter = logging.Formatter(
@@ -874,8 +875,8 @@ def check_config_complete():
     logging.debug("설정 완료 여부 확인 시작")
     try:
         # 모든 실행이 Docker 환경에서 이루어진다고 가정
-        config_path = '/config/config.yaml'
-        init_flag_path = '/config/.init_complete'
+        config_path = CONFIG_PATH
+        init_flag_path = INIT_FLAG_PATH
 
         # 초기화 완료 플래그 확인
         init_flag_exists = os.path.exists(init_flag_path)
@@ -949,7 +950,7 @@ if __name__ == "__main__":
     gshare_web_server = GshareWebServer()
     try:
         # 초기화 완료 플래그 경로
-        init_flag_path = '/config/.init_complete'
+        init_flag_path = INIT_FLAG_PATH
 
         # 설정 완료 여부 확인
         setup_completed = check_config_complete()

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -11,7 +11,8 @@ import pytz  # type: ignore
 import yaml  # type: ignore
 import socket
 import tempfile
-from config import GshareConfig  # type: ignore
+from config import (GshareConfig, CONFIG_PATH, INIT_FLAG_PATH,
+                    RESTART_FLAG_PATH, LOG_FILE_PATH)  # type: ignore
 import time
 import traceback
 from flask_socketio import SocketIO  # type: ignore
@@ -34,7 +35,7 @@ class GshareWebServer:
         self.manager = None
         self.config = None
         self.is_setup_complete = False
-        self.log_file = os.path.join('/logs', 'gshare_manager.log')
+        self.log_file = LOG_FILE_PATH
         # SocketIO 초기화
         self.socketio = SocketIO(self.app, cors_allowed_origins="*")
         self._setup_logging()
@@ -100,7 +101,7 @@ class GshareWebServer:
                     logging.warning(
                         "manager.current_state가 None 값입니다. 초기화가 필요할 수 있습니다.")
 
-            restart_flag_path = '/config/.restart_in_progress'
+            restart_flag_path = RESTART_FLAG_PATH
             if os.path.exists(restart_flag_path):
                 logging.debug("이전 재시작 플래그 파일이 발견되었습니다. 삭제합니다.")
                 try:
@@ -300,7 +301,7 @@ class GshareWebServer:
     def setup(self):
         """초기 설정 페이지"""
         container_ip = self._get_container_ip()
-        config_path = '/config/config.yaml'
+        config_path = CONFIG_PATH
         form_data = {}
         has_config = False
 
@@ -347,8 +348,8 @@ class GshareWebServer:
 
     def save_config(self):
         """설정 저장"""
-        config_path = '/config/config.yaml'
-        init_flag_path = '/config/.init_complete'
+        config_path = CONFIG_PATH
+        init_flag_path = INIT_FLAG_PATH
 
         logging.debug("설정 저장 시작")
 
@@ -558,7 +559,7 @@ class GshareWebServer:
     def get_log_level(self):
         """로그 레벨 가져오기"""
         try:
-            yaml_path = '/config/config.yaml'
+            yaml_path = CONFIG_PATH
 
             if os.path.exists(yaml_path):
                 with open(yaml_path, 'r', encoding='utf-8') as f:
@@ -740,7 +741,7 @@ class GshareWebServer:
         if not self.config:
             return jsonify({"error": "설정이 로드되지 않았습니다."}), 500
 
-        yaml_path = '/config/config.yaml'
+        yaml_path = CONFIG_PATH
 
         try:
             if os.path.exists(yaml_path):
@@ -805,7 +806,7 @@ class GshareWebServer:
     def get_transcoding_config(self):
         """트랜스코딩 설정 정보 제공"""
         try:
-            yaml_path = '/config/config.yaml'
+            yaml_path = CONFIG_PATH
             if os.path.exists(yaml_path):
                 with open(yaml_path, 'r', encoding='utf-8') as f:
                     yaml_config = yaml.safe_load(f)
@@ -863,7 +864,7 @@ class GshareWebServer:
             
             # 스캔 전 config.yaml에서 최신 규칙 재로드
             try:
-                config_path = '/config/config.yaml'
+                config_path = CONFIG_PATH
                 if os.path.exists(config_path):
                     with open(config_path, 'r', encoding='utf-8') as f:
                         yaml_config = yaml.safe_load(f)
@@ -1294,7 +1295,7 @@ class GshareWebServer:
     def export_config(self):
         """현재 설정 파일 내보내기"""
         try:
-            config_path = '/config/config.yaml'
+            config_path = CONFIG_PATH
 
             if not os.path.exists(config_path):
                 logging.warning("내보낼 설정 파일이 없습니다.")
@@ -1343,7 +1344,7 @@ class GshareWebServer:
             logging.info("앱 재시작 요청 받음")
             logging.info("──────────────────────────────────────────────────")
 
-            restart_flag_path = '/config/.restart_in_progress'
+            restart_flag_path = RESTART_FLAG_PATH
             with open(restart_flag_path, 'w') as f:
                 f.write(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
@@ -1360,7 +1361,7 @@ class GshareWebServer:
     def check_restart_status(self):
         """서버 재시작 상태 확인 엔드포인트"""
         try:
-            restart_flag_path = '/config/.restart_in_progress'
+            restart_flag_path = RESTART_FLAG_PATH
 
             if os.path.exists(restart_flag_path):
                 return jsonify({"restart_complete": False})
@@ -1429,7 +1430,7 @@ class GshareWebServer:
         logging.info("──────────────────────────────────────────────────")
 
         try:
-            restart_flag_path = '/config/.restart_in_progress'
+            restart_flag_path = RESTART_FLAG_PATH
 
             try:
                 flask_port = int(os.environ.get('FLASK_PORT', 5000))


### PR DESCRIPTION
Centralized hardcoded paths in `app/config.py` and refactored `main.py` and `web_server.py` to use them.

---
*PR created automatically by Jules for task [15961414516638165820](https://jules.google.com/task/15961414516638165820) started by @wooooooooooook*