### PR TITLE
🧹 Refactor Transcoder to use configurable done_filename

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,6 +81,8 @@ class GshareConfig:
     TRANSCODING_ENABLED: bool = False
     ## 트랜스코딩 규칙 목록
     TRANSCODING_RULES: List[Dict[str, Any]] = None
+    ## 트랜스코딩 완료 파일명
+    TRANSCODING_DONE_FILENAME: str = '.transcoding_done'
 
     def __post_init__(self):
         if self.TRANSCODING_RULES is None:
@@ -172,7 +174,8 @@ class GshareConfig:
             'MQTT_TOPIC_PREFIX': yaml_config['mqtt'].get('topic_prefix', 'gshare'),
             'HA_DISCOVERY_PREFIX': yaml_config['mqtt'].get('ha_discovery_prefix', 'homeassistant'),
             'TRANSCODING_ENABLED': yaml_config.get('transcoding', {}).get('enabled', False),
-            'TRANSCODING_RULES': yaml_config.get('transcoding', {}).get('rules', [])
+            'TRANSCODING_RULES': yaml_config.get('transcoding', {}).get('rules', []),
+            'TRANSCODING_DONE_FILENAME': yaml_config.get('transcoding', {}).get('done_filename', '.transcoding_done')
         }
 
         # NFS 설정 추가

--- a/app/transcoder.py
+++ b/app/transcoder.py
@@ -16,6 +16,7 @@ class Transcoder:
         self.config = config
         self.enabled = config.TRANSCODING_ENABLED
         self.rules = config.TRANSCODING_RULES or []
+        self.done_filename = config.TRANSCODING_DONE_FILENAME
         self._build_optimized_rules()
         self._processing = False  # 중복 실행 방지 플래그
         self._scan_cancel = False  # 스캔 취소 플래그
@@ -45,8 +46,8 @@ class Transcoder:
         self.config = config
         self.enabled = config.TRANSCODING_ENABLED
         self.rules = config.TRANSCODING_RULES or []
+        self.done_filename = config.TRANSCODING_DONE_FILENAME
         self._build_optimized_rules()
-
     def _build_optimized_rules(self):
         """규칙의 확장자를 미리 정규화하여 최적화된 구조 생성"""
         self._optimized_rules = []
@@ -143,11 +144,10 @@ class Transcoder:
             return optimized['original']
         return None
 
-    DONE_FILENAME = '.transcoding_done'
 
     def _load_done_list(self, directory: str) -> set:
         """디렉토리의 .transcoding_done 파일에서 이미 처리된 파일 목록을 로드"""
-        done_file = os.path.join(directory, self.DONE_FILENAME)
+        done_file = os.path.join(directory, self.done_filename)
         if not os.path.exists(done_file):
             return set()
         try:
@@ -158,7 +158,7 @@ class Transcoder:
 
     def _mark_done(self, directory: str, filename: str):
         """ファイルを .transcoding_doneに記録"""
-        done_file = os.path.join(directory, self.DONE_FILENAME)
+        done_file = os.path.join(directory, self.done_filename)
         try:
             with open(done_file, 'a', encoding='utf-8') as f:
                 f.write(f"{filename}\n")
@@ -218,7 +218,7 @@ class Transcoder:
                     # 임시 파일과 추적 파일 건너뛰기
                     if filename.endswith('.tmp') or '.transcoding_tmp.' in filename:
                         continue
-                    if filename == self.DONE_FILENAME:
+                    if filename == self.done_filename:
                         continue
 
                     # .transcoding_done 파일로 이미 처리 여부 확인
@@ -471,7 +471,7 @@ class Transcoder:
                     if filename.endswith('.tmp') or '.transcoding_tmp.' in filename:
                         logging.debug(f"임시 파일 건너뜀: {filename}")
                         continue
-                    if filename == self.DONE_FILENAME:
+                    if filename == self.done_filename:
                         continue
 
                     # .transcoding_done 파일로 이미 처리 여부 확인


### PR DESCRIPTION
Moves the hardcoded `.transcoding_done` filename to the `GshareConfig` class, allowing it to be configured via the YAML configuration file. This improves code health by centralizing configuration and removing magic strings.

**Changes:**
- Added `TRANSCODING_DONE_FILENAME` to `GshareConfig` in `app/config.py`.
- Updated `GshareConfig.load_config` to read the value from YAML (defaulting to `.transcoding_done`).
- Updated `Transcoder` in `app/transcoder.py` to use `config.TRANSCODING_DONE_FILENAME` instead of a hardcoded class attribute.
- Ensured `Transcoder.reload_config` updates the filename when configuration changes.

**Verification:**
- Verified with a script (`verify_change.py`) that mocks `GshareConfig` and confirms `Transcoder` correctly uses the configured filename and updates on reload.
- Verified syntax with `py_compile`.

---
*PR created automatically by Jules for task [11773341755165067543](https://jules.google.com/task/11773341755165067543) started by @wooooooooooook*