### PR TITLE
🧹 Refactor SMBManager: Extract duplicate logic into helper methods

### DIFF
--- a/app/smb_manager.py
+++ b/app/smb_manager.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 from config import GshareConfig  # type: ignore
+from typing import Optional, Tuple
 
 
 class SMBManager:
@@ -69,8 +70,7 @@ class SMBManager:
                                        capture_output=True).returncode == 0
             
             # 시스템에 사용자 존재 여부 확인
-            user_exists = subprocess.run(['id', self.config.SMB_USERNAME], 
-                                      capture_output=True).returncode == 0
+            user_exists = self._get_user_info(self.config.SMB_USERNAME) is not None
             
             # 사용자 관리 단계별 처리
             if user_in_samba:
@@ -280,6 +280,49 @@ class SMBManager:
             logging.error(f"SMB 공유 비활성화 실패: {e}")
             return False
 
+
+    def _get_user_info(self, username: str) -> Optional[Tuple[int, int]]:
+        """
+        사용자의 UID와 GID를 반환합니다.
+
+        Args:
+            username: 사용자 이름
+
+        Returns:
+            Optional[Tuple[int, int]]: (UID, GID) 튜플 (존재하지 않거나 오류 시 None)
+        """
+        try:
+            user_info = subprocess.run(
+                ['id', username], capture_output=True, text=True)
+            if user_info.returncode == 0:
+                info_parts = user_info.stdout.strip().split()
+                current_uid = int(
+                    info_parts[0].split('=')[1].split('(')[0])
+                current_gid = int(
+                    info_parts[1].split('=')[1].split('(')[0])
+                return current_uid, current_gid
+        except Exception as e:
+            logging.error(f"사용자 확인 중 오류 ({username}): {e}")
+        return None
+
+    def _get_group_name(self, gid: int) -> Optional[str]:
+        """
+        GID에 해당하는 그룹 이름을 반환합니다.
+
+        Args:
+            gid: 그룹 ID
+
+        Returns:
+            Optional[str]: 그룹 이름 (존재하지 않거나 오류 시 None)
+        """
+        try:
+            group_info = subprocess.run(
+                ['getent', 'group', str(gid)], capture_output=True, text=True)
+            if group_info.returncode == 0:  # 해당 GID를 가진 그룹이 존재
+                return group_info.stdout.strip().split(':')[0]
+        except Exception as e:
+            logging.error(f"그룹 확인 중 오류 ({gid}): {e}")
+        return None
     def _set_smb_user_ownership(self) -> None:
         """SMB 사용자의 UID/GID를 NFS 마운트 경로와 동일하게 설정"""
         try:
@@ -300,15 +343,10 @@ class SMBManager:
             current_gid = 0
 
             try:
-                user_info = subprocess.run(
-                    ['id', smb_username], capture_output=True, text=True)
-                if user_info.returncode == 0:  # 사용자 존재
+                user_info_tuple = self._get_user_info(smb_username)
+                if user_info_tuple:  # 사용자 존재
                     user_exists = True
-                    info_parts = user_info.stdout.strip().split()
-                    current_uid = int(
-                        info_parts[0].split('=')[1].split('(')[0])
-                    current_gid = int(
-                        info_parts[1].split('=')[1].split('(')[0])
+                    current_uid, current_gid = user_info_tuple
                     uid_gid_match = (
                         current_uid == self.nfs_uid and current_gid == self.nfs_gid)
                     logging.debug(
@@ -319,16 +357,9 @@ class SMBManager:
                 logging.error(f"사용자 확인 중 오류: {e}")
 
             # NFS GID가 이미 존재하는 그룹에 할당되어 있는지 확인
-            existing_group = None
-            try:
-                group_info = subprocess.run(['getent', 'group', str(
-                    self.nfs_gid)], capture_output=True, text=True)
-                if group_info.returncode == 0:  # 해당 GID를 가진 그룹이 존재
-                    existing_group = group_info.stdout.strip().split(':')[0]
-                    logging.debug(
-                        f"GID {self.nfs_gid}를 가진 기존 그룹 발견: {existing_group}")
-            except Exception as e:
-                logging.error(f"그룹 확인 중 오류: {e}")
+            existing_group = self._get_group_name(self.nfs_gid)
+            if existing_group:
+                logging.debug(f"GID {self.nfs_gid}를 가진 기존 그룹 발견: {existing_group}")
 
             # 사용자 처리 로직
             if not user_exists:
@@ -475,15 +506,7 @@ class SMBManager:
 
             try:
                 # NFS GID가 이미 존재하는 그룹에 할당되어 있는지 확인
-                existing_group = None
-                try:
-                    group_info = subprocess.run(['getent', 'group', str(
-                        self.nfs_gid)], capture_output=True, text=True)
-                    if group_info.returncode == 0:  # 해당 GID를 가진 그룹이 존재
-                        existing_group = group_info.stdout.strip().split(':')[
-                            0]
-                except Exception as e:
-                    logging.error(f"그룹 확인 중 오류: {e}")
+                existing_group = self._get_group_name(self.nfs_gid)
 
                 # 적절한 그룹 이름 결정
                 group_name = existing_group if existing_group else self.config.SMB_USERNAME
@@ -561,14 +584,7 @@ class SMBManager:
             # SMB 사용자의 소유권으로 변경
             try:
                 # NFS GID가 이미 존재하는 그룹에 할당되어 있는지 확인
-                existing_group = None
-                try:
-                    group_info = subprocess.run(['getent', 'group', str(
-                        self.nfs_gid)], capture_output=True, text=True)
-                    if group_info.returncode == 0:  # 해당 GID를 가진 그룹이 존재
-                        existing_group = group_info.stdout.strip().split(':')[0]
-                except Exception as e:
-                    logging.error(f"그룹 확인 중 오류: {e}")
+                existing_group = self._get_group_name(self.nfs_gid)
 
                 # 적절한 그룹 이름 결정
                 group_name = existing_group if existing_group else self.config.SMB_USERNAME
@@ -612,14 +628,7 @@ class SMBManager:
         try:
             if os.path.exists(self.links_dir):
                 # NFS GID가 이미 존재하는 그룹에 할당되어 있는지 확인
-                existing_group = None
-                try:
-                    group_info = subprocess.run(['getent', 'group', str(
-                        self.nfs_gid)], capture_output=True, text=True)
-                    if group_info.returncode == 0:  # 해당 GID를 가진 그룹이 존재
-                        existing_group = group_info.stdout.strip().split(':')[0]
-                except Exception as e:
-                    logging.error(f"그룹 확인 중 오류: {e}")
+                existing_group = self._get_group_name(self.nfs_gid)
 
                 # 적절한 그룹 이름 결정
                 group_name = existing_group if existing_group else self.config.SMB_USERNAME

--- a/test_smb_manager.py
+++ b/test_smb_manager.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+import sys
+import os
+
+# Mock yaml module before importing config
+sys.modules['yaml'] = MagicMock()
+
+# Add app directory to path
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app'))
+
+from smb_manager import SMBManager
+
+class DummyConfig:
+    SMB_LINKS_DIR = '/tmp/links'
+    SMB_USERNAME = 'smbuser'
+    SMB_PASSWORD = 'password'
+    SMB_PORT = 445
+    SMB_SHARE_NAME = 'gshare'
+    SMB_COMMENT = 'comment'
+    SMB_GUEST_OK = False
+    MOUNT_PATH = '/mnt/gshare'
+
+class TestSMBManagerRefactor(unittest.TestCase):
+    def setUp(self):
+        # Patch methods called in __init__
+        self.patcher_init = patch('smb_manager.SMBManager._init_smb_config')
+        self.patcher_ownership = patch('smb_manager.SMBManager._set_smb_user_ownership')
+        self.patcher_perms = patch('smb_manager.SMBManager._set_links_directory_permissions')
+        self.patcher_cleanup = patch('smb_manager.SMBManager.cleanup_all_symlinks')
+
+        self.mock_init = self.patcher_init.start()
+        self.mock_ownership = self.patcher_ownership.start()
+        self.mock_perms = self.patcher_perms.start()
+        self.mock_cleanup = self.patcher_cleanup.start()
+
+        self.config = DummyConfig()
+        self.smb_manager = SMBManager(self.config, 1000, 1000)
+
+    def tearDown(self):
+        self.patcher_init.stop()
+        self.patcher_ownership.stop()
+        self.patcher_perms.stop()
+        self.patcher_cleanup.stop()
+
+    @patch('smb_manager.subprocess.run')
+    def test_get_user_info_success(self, mock_run):
+        # This method doesn't exist yet, so we only run if it exists
+        if not hasattr(self.smb_manager, '_get_user_info'):
+            return
+
+        # Mock successful id command
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "uid=1001(smbuser) gid=1001(smbuser) groups=1001(smbuser)"
+
+        uid, gid = self.smb_manager._get_user_info('smbuser')
+        self.assertEqual(uid, 1001)
+        self.assertEqual(gid, 1001)
+        mock_run.assert_called_with(['id', 'smbuser'], capture_output=True, text=True)
+
+    @patch('smb_manager.subprocess.run')
+    def test_get_user_info_fail(self, mock_run):
+        if not hasattr(self.smb_manager, '_get_user_info'):
+            return
+
+        # Mock failed id command
+        mock_run.return_value.returncode = 1
+
+        result = self.smb_manager._get_user_info('nonexistent')
+        self.assertIsNone(result)
+
+    @patch('smb_manager.subprocess.run')
+    def test_get_group_name_success(self, mock_run):
+        if not hasattr(self.smb_manager, '_get_group_name'):
+            return
+
+        # Mock successful getent group command
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "mygroup:x:1001:"
+
+        group_name = self.smb_manager._get_group_name(1001)
+        self.assertEqual(group_name, "mygroup")
+        mock_run.assert_called_with(['getent', 'group', '1001'], capture_output=True, text=True)
+
+    @patch('smb_manager.subprocess.run')
+    def test_get_group_name_fail(self, mock_run):
+        if not hasattr(self.smb_manager, '_get_group_name'):
+            return
+
+        # Mock failed getent group command
+        mock_run.return_value.returncode = 1
+
+        result = self.smb_manager._get_group_name(9999)
+        self.assertIsNone(result)
+
+    def test_init_smb_config_calls_get_user_info(self):
+        # We need to run the real _init_smb_config.
+        # Stop patcher to run real method
+        self.patcher_init.stop()
+
+        try:
+            # Mock internal calls
+            with patch('smb_manager.subprocess.run') as mock_run,                  patch('smb_manager.open', mock_open()),                  patch.object(self.smb_manager, '_get_user_info', return_value=(1000, 1000)) as mock_get_user_info:
+
+                mock_run.return_value.returncode = 0
+
+                self.smb_manager._init_smb_config()
+
+                # Check call
+                mock_get_user_info.assert_called()
+        finally:
+            self.patcher_init.start()
+
+    def test_set_links_directory_permissions_calls_get_group_name(self):
+        self.patcher_perms.stop()
+
+        try:
+            with patch('smb_manager.subprocess.run') as mock_run,                  patch('smb_manager.os.path.exists', return_value=True),                  patch('smb_manager.os.makedirs'),                  patch('smb_manager.os.chmod'),                  patch.object(self.smb_manager, '_get_group_name', return_value='somegroup') as mock_get_group_name:
+
+                self.smb_manager._set_links_directory_permissions('/tmp')
+
+                mock_get_group_name.assert_called_with(1000)
+
+                # Verify chown called with group name
+                found = False
+                for call in mock_run.call_args_list:
+                    args = call[0][0]
+                    # args is list of strings like ['chown', 'smbuser:somegroup', '/tmp']
+                    if 'chown' in args and 'smbuser:somegroup' in args:
+                        found = True
+                        break
+                self.assertTrue(found, "Should call chown with correct group name")
+        finally:
+            self.patcher_perms.start()
+
+if __name__ == '__main__':
+    unittest.main()
+
+    def test_create_symlink_calls_get_group_name(self):
+        try:
+            with patch('smb_manager.subprocess.run') as mock_run,                  patch('smb_manager.os.path.exists', side_effect=[False, False]),                  patch('smb_manager.os.remove'),                  patch('smb_manager.os.symlink'),                  patch.object(self.smb_manager, '_get_group_name', return_value='linkgroup') as mock_get_group_name:
+
+                self.smb_manager.create_symlink('subfolder')
+
+                mock_get_group_name.assert_called_with(1000)
+
+                # Verify chown called with group name
+                found = False
+                for call in mock_run.call_args_list:
+                    args = call[0][0]
+                    # args might include '-h'
+                    if 'chown' in args and 'smbuser:linkgroup' in args:
+                        found = True
+                        break
+                self.assertTrue(found, "Should call chown -h with correct group name")
+        finally:
+            pass


### PR DESCRIPTION
**What:** Extracted `_get_user_info` and `_get_group_name` helper methods in `app/smb_manager.py` to eliminate duplicate logic for checking system users and groups.

**Why:** The `id` command parsing logic was duplicated in `_init_smb_config` and `_set_smb_user_ownership`. The `getent group` command logic was duplicated 4 times across `_set_links_directory_permissions`, `create_symlink`, and `_fix_symlinks_ownership`. Centralizing this logic improves maintainability and readability.

**Verification:** Added `test_smb_manager.py` with unit tests for the helper methods and verified that the refactored methods call these helpers correctly. All 6 tests passed.

**Result:** Code is cleaner and less repetitive. Future changes to user/group lookup logic only need to be done in one place.

---
*PR created automatically by Jules for task [14185045435445644503](https://jules.google.com/task/14185045435445644503) started by @wooooooooooook*