### PR TITLE
Refactor hardcoded config paths

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 import os
 import yaml
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, ClassVar
 
 @dataclass
 class GshareConfig:
+    CONFIG_FILE_PATH: ClassVar[str] = '/config/config.yaml'
+    TEMPLATE_FILE_PATH: ClassVar[str] = '/config/config.yaml.template'
     # Proxmox android 사용량 감시
     ## Proxmox API 호스트
     PROXMOX_HOST: str
@@ -90,7 +92,7 @@ class GshareConfig:
     def load_config(cls) -> 'GshareConfig':
         """설정 파일에서 설정 로드"""
         # Docker 환경을 가정하고 설정 파일 경로 고정
-        config_path = '/config/config.yaml'
+        config_path = cls.CONFIG_FILE_PATH
         
         try:
             if os.path.exists(config_path):
@@ -185,7 +187,7 @@ class GshareConfig:
     def update_yaml_config(config_dict: Dict[str, Any]) -> None:
         """YAML 설정 파일 업데이트"""
         # Docker 환경을 가정하고 설정 파일 경로 고정
-        yaml_path = '/config/config.yaml'
+        yaml_path = GshareConfig.CONFIG_FILE_PATH
         
         try:
             if os.path.exists(yaml_path):
@@ -311,7 +313,7 @@ class GshareConfig:
     @staticmethod
     def load_template_config() -> Dict[str, Any]:
         """템플릿 설정 파일 로드"""
-        template_path = '/config/config.yaml.template'
+        template_path = GshareConfig.TEMPLATE_FILE_PATH
         
         try:
             if os.path.exists(template_path):

--- a/app/main.py
+++ b/app/main.py
@@ -766,7 +766,7 @@ class GShareManager:
 def setup_logging():
     """기본 로깅 설정을 초기화"""
     # config.yaml에서 로그 레벨 확인
-    yaml_path = '/config/config.yaml'
+    yaml_path = GshareConfig.CONFIG_FILE_PATH
     log_level = 'INFO'  # 기본값
 
     try:
@@ -874,7 +874,7 @@ def check_config_complete():
     logging.debug("설정 완료 여부 확인 시작")
     try:
         # 모든 실행이 Docker 환경에서 이루어진다고 가정
-        config_path = '/config/config.yaml'
+        config_path = GshareConfig.CONFIG_FILE_PATH
         init_flag_path = '/config/.init_complete'
 
         # 초기화 완료 플래그 확인

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -300,7 +300,7 @@ class GshareWebServer:
     def setup(self):
         """초기 설정 페이지"""
         container_ip = self._get_container_ip()
-        config_path = '/config/config.yaml'
+        config_path = GshareConfig.CONFIG_FILE_PATH
         form_data = {}
         has_config = False
 
@@ -347,7 +347,7 @@ class GshareWebServer:
 
     def save_config(self):
         """설정 저장"""
-        config_path = '/config/config.yaml'
+        config_path = GshareConfig.CONFIG_FILE_PATH
         init_flag_path = '/config/.init_complete'
 
         logging.debug("설정 저장 시작")
@@ -558,7 +558,7 @@ class GshareWebServer:
     def get_log_level(self):
         """로그 레벨 가져오기"""
         try:
-            yaml_path = '/config/config.yaml'
+            yaml_path = GshareConfig.CONFIG_FILE_PATH
 
             if os.path.exists(yaml_path):
                 with open(yaml_path, 'r', encoding='utf-8') as f:
@@ -740,7 +740,7 @@ class GshareWebServer:
         if not self.config:
             return jsonify({"error": "설정이 로드되지 않았습니다."}), 500
 
-        yaml_path = '/config/config.yaml'
+        yaml_path = GshareConfig.CONFIG_FILE_PATH
 
         try:
             if os.path.exists(yaml_path):
@@ -805,7 +805,7 @@ class GshareWebServer:
     def get_transcoding_config(self):
         """트랜스코딩 설정 정보 제공"""
         try:
-            yaml_path = '/config/config.yaml'
+            yaml_path = GshareConfig.CONFIG_FILE_PATH
             if os.path.exists(yaml_path):
                 with open(yaml_path, 'r', encoding='utf-8') as f:
                     yaml_config = yaml.safe_load(f)
@@ -863,7 +863,7 @@ class GshareWebServer:
             
             # 스캔 전 config.yaml에서 최신 규칙 재로드
             try:
-                config_path = '/config/config.yaml'
+                config_path = GshareConfig.CONFIG_FILE_PATH
                 if os.path.exists(config_path):
                     with open(config_path, 'r', encoding='utf-8') as f:
                         yaml_config = yaml.safe_load(f)
@@ -1294,7 +1294,7 @@ class GshareWebServer:
     def export_config(self):
         """현재 설정 파일 내보내기"""
         try:
-            config_path = '/config/config.yaml'
+            config_path = GshareConfig.CONFIG_FILE_PATH
 
             if not os.path.exists(config_path):
                 logging.warning("내보낼 설정 파일이 없습니다.")


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded `/config/config.yaml` and `/config/config.yaml.template` strings with `GshareConfig.CONFIG_FILE_PATH` and `GshareConfig.TEMPLATE_FILE_PATH` constants.
💡 **Why:** To improve maintainability and avoid duplication of configuration paths. Centralizing the path definition makes it easier to update if the location changes.
✅ **Verification:** Verified that all occurrences in `app/config.py`, `app/web_server.py`, and `app/main.py` are replaced and syntax is correct.
✨ **Result:** Codebase is cleaner and more maintainable with centralized configuration paths.

---
*PR created automatically by Jules for task [1001249196600114153](https://jules.google.com/task/1001249196600114153) started by @wooooooooooook*