### PR TITLE
⚡ Bolt: Optimize SMB Link Checks with Cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2026-02-20 - [Proxmox API Request Coalescing]
 **Learning:** Sequential API calls to the same endpoint within a tight loop (e.g., monitor loop) can cause significant redundant network traffic. In `ProxmoxAPI`, 3 separate methods were calling the same endpoint 6 times per loop iteration.
 **Action:** Implement short-term caching (TTL) for frequently accessed, slowly changing data like VM status to coalesce multiple logical requests into a single physical request per loop iteration.
+
+## 2025-05-18 - [FolderMonitor Perf]
+**Learning:** Frequent syscalls like `os.path.exists` in a tight loop (e.g., status reporting every tick for thousands of items) can block the event loop and degrade performance.
+**Action:** Use memory caching for file status (e.g., `set` of active symlinks) when possible, updating the cache on file operations instead of polling the disk.

--- a/app/main.py
+++ b/app/main.py
@@ -365,12 +365,8 @@ class FolderMonitor:
 
         monitored_folders = {}
         for path, mtime in folder_times:
-            # 실제 심볼릭 링크가 존재하는지 확인
-            # SMBManager에서 사용하는 링크 경로 값 사용
-            links_dir = self.smb_manager.links_dir
-            symlink_path = os.path.join(links_dir, path.replace(os.sep, '_'))
-            is_mounted = os.path.exists(
-                symlink_path) and os.path.islink(symlink_path)
+            # 실제 심볼릭 링크가 존재하는지 확인 (메모리 캐시 사용)
+            is_mounted = self.smb_manager.is_link_active(path)
 
             monitored_folders[path] = {
                 'mtime': datetime.fromtimestamp(mtime, pytz.timezone(self.config.TIMEZONE)).strftime('%Y-%m-%d %H:%M:%S'),


### PR DESCRIPTION
💡 What:
- Introduced `_active_links` set in `SMBManager` to cache active symlinks.
- Implemented `is_link_active` method to check link status using memory instead of `os.path.exists` + `os.path.islink`.
- Updated `FolderMonitor.get_monitored_folders` in `app/main.py` to use `is_link_active`.
- Updated `test_smb_manager.py` with unit tests for caching logic.

🎯 Why:
- `FolderMonitor.get_monitored_folders` is called in the main monitoring loop.
- Previously, it performed `os.path.exists` and `os.path.islink` for every monitored folder (potentially thousands) on every tick.
- This caused significant CPU usage and I/O overhead on large filesystems.

📊 Impact:
- Reduces syscalls for link checking from O(N) per tick to O(1) (set lookup).
- Improves responsiveness of the monitoring loop.
- Reduces disk activity on the underlying filesystem (NFS/local).

🔬 Measurement:
- Verified with `test_smb_manager.py` that the cache is correctly updated on create/remove/cleanup operations.
- The `is_link_active` check is purely in-memory.

---
*PR created automatically by Jules for task [1080323864553791885](https://jules.google.com/task/1080323864553791885) started by @wooooooooooook*