### PR TITLE
⚡ Bolt: Optimize transcoding manual scan

### DIFF
--- a/app/transcoder.py
+++ b/app/transcoder.py
@@ -410,7 +410,23 @@ class Transcoder:
             
             logging.info(f"폴더 필터링 완료: {len(subfolders)}개 중 {len(filtered_subs)}개 폴더가 규칙에 매칭됨")
             
-            for sub in filtered_subs:
+            # 최적화: 중복 스캔 방지 (상위 폴더가 포함되어 있으면 하위 폴더 제외)
+            filtered_subs.sort()
+            unique_subs = []
+            if filtered_subs:
+                unique_subs.append(filtered_subs[0])
+                for i in range(1, len(filtered_subs)):
+                    prev = unique_subs[-1]
+                    curr = filtered_subs[i]
+                    # prev가 curr의 상위 폴더인지 확인 (curr이 prev + os.sep로 시작하거나 동일한 경우)
+                    if curr == prev or curr.startswith(prev + os.sep):
+                        continue
+                    unique_subs.append(curr)
+
+            if len(unique_subs) < len(filtered_subs):
+                logging.info(f"중복/하위 폴더 제거됨: {len(filtered_subs)} -> {len(unique_subs)}개 (최적화)")
+
+            for sub in unique_subs:
                 full_path = os.path.join(folder_path, sub)
                 if os.path.exists(full_path):
                     scan_roots.append(full_path)


### PR DESCRIPTION
⚡ Bolt: Optimize transcoding manual scan

💡 What:
Implemented logic in `Transcoder.collect_matching_files` to filter out subdirectories from the scan list if their parent directory is already included.

🎯 Why:
When users trigger a manual scan (e.g., via the web UI) with multiple folders selected, `os.walk` is called on each folder. If a parent folder and its subfolder are both selected (e.g., `Movies` and `Movies/Action`), the subfolder's contents are scanned twice—once as part of the parent's recursive scan and once explicitly. This redundant scanning wastes I/O and CPU resources.

📊 Impact:
Eliminates redundant file system traversals for nested folder selections.
- If `Movies` (containing 1000 files) and `Movies/Action` (containing 100 files) are both selected, the scan now processes 1000 files instead of 1100.
- Performance improvement scales with the size of the redundant subfolders.

🔬 Measurement:
Verified logic with a temporary unit test `test_transcoder_opt.py` confirming that `['A', 'A/B']` is reduced to `['A']`.
Existing project tests passed (`test_smb_manager.py`).
Manual verification of syntax via python import.


---
*PR created automatically by Jules for task [12336375620051809866](https://jules.google.com/task/12336375620051809866) started by @wooooooooooook*