### PR TITLE
⚡ Bolt: FolderMonitor 하위폴더 검사 O(n²)→O(n log n) 최적화

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2025-05-18 - [FolderMonitor Perf]
 **Learning:** Frequent syscalls like `os.path.exists` in a tight loop (e.g., status reporting every tick for thousands of items) can block the event loop and degrade performance.
 **Action:** Use memory caching for file status (e.g., `set` of active symlinks) when possible, updating the cache on file operations instead of polling the disk.
+
+## 2026-02-20 - [Mount Target Selection Complexity]
+**Learning:** `FolderMonitor._filter_mount_targets` had an O(n²) child-folder detection loop (`for path` × `for other in folder_set`) that can dominate scan cycles when many folders change at once.
+**Action:** Keep path collections lexicographically sorted and use binary search prefix checks for descendant existence to keep the hot path closer to O(n log n).


### PR DESCRIPTION
### Motivation
- `FolderMonitor._filter_mount_targets`에서 각 경로마다 전체 `folder_set`를 순회하는 O(n²) 로직이 다수 변경이 발생할 때 스캔 루프의 병목이 될 수 있어 개선이 필요했습니다.
- 작은 코드 변경으로 스캔 주기의 비용을 크게 낮춰 모니터링 루프 응답성을 개선하려는 목적입니다.

### Description
- `app/main.py`의 `_filter_mount_targets`에서 전체 집합을 반복 검사하던 중첩 루프를 제거하고 경로를 사전식으로 정렬한 `lexicographic_paths`와 `bisect_right` 기반 prefix 검사로 변경했습니다.
- 하위 폴더 존재 여부를 O(log n)로 판단하는 `has_child_folder` 헬퍼를 도입해 전체 검사 복잡도를 O(n²)에서 O(n log n)로 개선했습니다.
- 개선 의도를 설명하는 주석을 코드에 추가했고, 변경 내역과 학습 내용을 `.jules/bolt.md`에 기록했습니다.
- 변경 파일: `app/main.py`, `.jules/bolt.md`.

### Testing
- 빌드/컴파일: `python -m compileall app`를 실행하여 컴파일이 성공했음을 확인했습니다 (성공).
- 정적검사: `ruff check .`를 실행했으며 이번 변경과 무관한 기존 lint 문제(19건)가 보고되어 실패했습니다(기존 코드베이스 이슈로 판단).
- 단위테스트: `pytest -q`를 실행하여 전체 테스트가 통과함을 확인했습니다 (`8 passed`).
- 성능측정: 로컬 합성 벤치마크(약 4.9k 경로, 5회 반복)에서 child-detection 부분의 실행시간이 `old=19.7729s` → `new=0.0251s`로 측정되어 약 **788x** 속도 향상을 보였습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e75ab0dc832c8837141874ac40f4)