### PR TITLE
SMB 활성화 중복 재시작 방지 최적화

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -808,9 +808,12 @@ class GShareManager:
                                 except Exception as te:
                                     logging.error(f"트랜스코딩 오류 ({folder}): {te}")
 
-                        # 변경된 폴더들의 SMB 공유 활성화
-                        if self.smb_manager.activate_smb_share():
-                            self.last_action = f"SMB 공유 활성화: {', '.join(changed_folders)}"
+                        # SMB가 비활성 상태일 때만 공유 활성화(활성 상태 재시작 방지)
+                        if mount_targets:
+                            if self.smb_manager.check_smb_status():
+                                logging.debug("SMB 공유가 이미 활성화되어 있어 재시작을 생략합니다.")
+                            elif self.smb_manager.activate_smb_share():
+                                self.last_action = f"SMB 공유 활성화: {', '.join(changed_folders)}"
 
                         # VM이 정지 상태이고 최근 수정된 파일이 있는 경우에만 시작
                         if not self.proxmox_api.is_vm_running() and should_start_vm:


### PR DESCRIPTION
### Motivation
- 변경 폴더 감지 루프에서 SMB 공유가 이미 활성화된 경우 불필요하게 `activate_smb_share()`를 다시 호출해 Samba 재시작이 발생하는 것을 방지하려는 목적입니다.

### Description
- `app/main.py`의 폴더 변경 처리 로직에서 `mount_targets`가 있을 때만 SMB 활성화 경로를 실행하도록 분기했습니다.
- 활성화 전에 `self.smb_manager.check_smb_status()`를 호출해 SMB가 이미 실행 중이면 디버그 로그를 남기고 재시작을 생략하도록 했습니다.
- SMB가 비활성 상태일 때만 `activate_smb_share()`를 호출하고 성공 시 `self.last_action`을 갱신하도록 변경했습니다.

### Testing
- `poetry run python -m compileall app`를 실행해 코드 컴파일을 확인했고 성공했습니다.
- `poetry run ruff check .`를 실행했으며, 이번 변경과는 무관한 기존 코드베이스의 lint 이슈로 실패했습니다.
- `poetry run pytest`를 실행해 테스트를 검증했으며 모든 테스트가 통과했습니다 (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ea0fd474832ca70f8b213da090bd)