### PR TITLE
⚡ Bolt: timezone 객체 캐싱으로 모니터 핫패스 최적화

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2026-02-20 - [Mount Target Selection Complexity]
 **Learning:** `FolderMonitor._filter_mount_targets` had an O(n²) child-folder detection loop (`for path` × `for other in folder_set`) that can dominate scan cycles when many folders change at once.
 **Action:** Keep path collections lexicographically sorted and use binary search prefix checks for descendant existence to keep the hot path closer to O(n log n).
+
+## 2026-02-20 - [Timezone Object Reuse in Monitor Loop]
+**Learning:** `pytz.timezone(self.config.TIMEZONE)` was being recreated repeatedly in hot paths (`update_state`, folder change formatting). In this codebase's monitor-driven architecture, that adds avoidable lookup overhead every cycle.
+**Action:** Cache timezone objects once per manager/monitor instance (`self.local_tz`) and reuse for all timestamp formatting/conversion in looped code paths.


### PR DESCRIPTION
### Motivation
- 모니터링 루프와 상태 갱신의 핫패스에서 `pytz.timezone(self.config.TIMEZONE)`가 반복 생성되어 불필요한 오버헤드가 발생하므로 이를 줄이기 위함입니다.

### Description
- `FolderMonitor`와 `GShareManager`에 `self.local_tz`를 추가해 `pytz.timezone(...)` 객체를 1회만 생성하여 재사용하도록 변경했습니다 (파일: `app/main.py`).
- 상태 업데이트 및 폴더 타임스탬프 포맷팅 등 빈번하게 호출되는 경로에서 반복 호출을 캐시된 `self.local_tz`로 대체했습니다.
- 최적화 목적과 기대 효과를 설명하는 인라인 주석을 추가했습니다.
- 이번 학습 내용을 Bolt 저널에 기록했습니다 (`.jules/bolt.md`).

### Testing
- 애플리케이션 모듈 컴파일 검증을 위해 `python -m compileall app`를 실행했고 정상 완료되었습니다.
- 단위 테스트 `python -m unittest -q`를 실행했고 8개 테스트가 모두 통과하여 `OK`였습니다.
- 코드 스타일 검사 `python -m flake8 app`는 환경에 `flake8`이 없어 실행 불가로 보고했습니다.
- 성능 측정(마이크로 벤치마크): `pytz.timezone("Asia/Seoul")` 100k 호출 약 `0.129756s`, 캐시 재사용(reference) 100k 호출 약 `0.002067s`, 대략 `~62.8x` 속도 향상을 관찰했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998edfa02c8832cb9dd5aa25bda61b7)