### PR TITLE
⚡ Bolt: NFS 마운트 상태 TTL 캐시 추가

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2026-02-20 - [SMB 링크 제거 경로의 디렉토리 스캔 비용]
 **Learning:** `SMBManager.remove_symlink`가 링크 하나 삭제할 때마다 `os.listdir + os.path.islink`로 links_dir 전체를 스캔해, 링크 수가 많을수록 O(n) syscall 비용이 반복됐다.
 **Action:** 링크 활성 상태는 메모리 캐시(`_active_links`)를 우선 사용하고, 캐시가 비었을 때만 디스크를 1회 재검증하는 패턴을 유지한다.
+
+## 2026-02-20 - [NFS Mount Probe TTL Caching]
+**Learning:** 상태 갱신 루프에서 `mount -t nfs` subprocess 호출은 회당 수 ms 비용이 있어, 루프마다 수행하면 누적 syscall 오버헤드가 커진다.
+**Action:** 마운트 상태처럼 변동이 낮은 값은 짧은 TTL(예: 5초) 캐시를 적용해 루프 내 반복 호출을 캐시 hit로 흡수한다.


### PR DESCRIPTION
### Motivation
- 상태 갱신 루프에서 `mount -t nfs`를 자주 호출하면 프로세스 생성/시스템 콜 오버헤드가 쌓이므로 짧은 TTL 캐시로 반복 호출을 줄여 폴링 비용을 낮추기 위함입니다.

### Description
- `FolderMonitor`에 `_nfs_status_cache`, `_nfs_status_checked_at`, `_nfs_status_ttl`(기본 5초) 필드를 추가해 NFS 마운트 상태를 TTL 기반으로 캐시하도록 구현했습니다.
- `check_nfs_status()`에 캐시 히트 시 빠른 반환 로직을 추가하고, 실제 `mount -t nfs` 호출 결과를 캐시에 저장하도록 변경했으며 예외 발생 시 마지막 캐시값을 우선 반환하도록 했습니다.
- 최적화 의도와 로컬 마이크로벤치(콜드/핫 경로 수치)를 코드 주석으로 남기고, 변경 학습을 `.jules/bolt.md`에 기록했습니다.
- 최적화 목적의 주석을 추가하여 코드 가독성을 유지하도록 했습니다.

### Testing
- `python -m compileall app` 실행: 성공.
- `PYTHONPATH=app python -m unittest -v` 실행: 모든 유닛테스트 통과 (8 tests, OK).
- 로컬 마이크로벤치(제거/캐시 경로 비교): 콜드 경로 약 `6.628ms/call`, 캐시 히트 경로 약 `0.000552ms/call`으로 캐시 히트 시 호출 비용이 크게 감소함을 확인했습니다.
- `python -m flake8 app test_smb_manager.py` 실행은 현재 환경에 `flake8` 미설치로 실패/스킵 상태였습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f16df948832cb0040257562caa97)