### PR TITLE
포터블 `find` 환경에서 폴더 스캔 폴백 개선

### DIFF
--- a/test_folder_monitor_scan.py
+++ b/test_folder_monitor_scan.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock external modules before importing main
+sys.modules['proxmox_api'] = MagicMock()
+sys.modules['mqtt_manager'] = MagicMock()
+sys.modules['web_server'] = MagicMock()
+sys.modules['transcoder'] = MagicMock()
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app'))
+from main import FolderMonitor
+
+
+class DummyConfig:
+    def __init__(self, mount_path):
+        self.MOUNT_PATH = mount_path
+        self.SMB_LINKS_DIR = '/tmp/links'
+        self.TIMEZONE = 'UTC'
+
+
+class TestFolderMonitorFindFallback(unittest.TestCase):
+    @patch('main.SMBManager')
+    @patch('main.FolderMonitor._get_nfs_ownership', return_value=(1000, 1000))
+    def test_scan_folders_hybrid_falls_back_to_portable_find(self, _mock_ownership, _mock_smb):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, 'A'))
+            os.makedirs(os.path.join(root, 'B', 'C'))
+            with open(os.path.join(root, 'A', 'a.txt'), 'w', encoding='utf-8') as f:
+                f.write('x')
+            with open(os.path.join(root, 'B', 'C', 'c.txt'), 'w', encoding='utf-8') as f:
+                f.write('x')
+
+            monitor = FolderMonitor(DummyConfig(root), MagicMock(), 0.0)
+
+            first_error = __import__('subprocess').CalledProcessError(1, ['find'])
+            second_ok = MagicMock(stdout='./A/a.txt\0./B/C/c.txt\0')
+
+            with patch('main.subprocess.run', side_effect=[first_error, second_ok]) as mock_run:
+                result = monitor._scan_folders_hybrid()
+
+            self.assertIn('A', result)
+            self.assertIn('B/C', result)
+            self.assertEqual(mock_run.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- NFS/BusyBox 등 일부 환경에서 `find -printf`가 지원되지 않으면 하이브리드 스캔이 실패하고 느린 파이썬 순회로 바로 폴백되어 대규모 트리에서 스캔 시간이 급격히 증가할 수 있습니다.
- 안정적으로 대규모(예: 폴더 1천, 파일 7만) 환경에서 mtime 기반 폴더 검사를 빠르게 수행할 수 있도록 폴백 로직을 개선할 필요가 있었습니다.

### Description
- `FolderMonitor._scan_folders_hybrid()`에서 `find -printf` 실패 시 즉시 파이썬 순회로 가지 않고 먼저 포터블 `find` 경로로 폴백하도록 변경했습니다.
- 새로운 메서드 `FolderMonitor._scan_folders_find_portable()`를 추가해 `find -print0`로 파일 목록을 수집하고 파일의 부모 폴더 집합을 만들어 각 폴더의 `st_mtime`을 수집하도록 구현했습니다.
- 포터블 결과에서 `./` 프리픽스를 제거해 기존 결과 키 포맷(`A`, `B/C`)과 일관되게 정규화했습니다.
- GNU `find` 실패 상황을 검증하는 단위 테스트 파일 `test_folder_monitor_scan.py`를 추가했습니다.

### Testing
- `python -m compileall app test_folder_monitor_scan.py test_smb_manager.py`를 실행해 코드 컴파일이 성공했음을 확인했습니다 (성공).
- `python -m unittest test_folder_monitor_scan.py test_smb_manager.py`를 실행해 유닛 테스트를 수행했고, 최종 상태에서 모든 테스트가 통과했습니다 (성공).
- `python -m pyflakes app test_folder_monitor_scan.py test_smb_manager.py`를 시도했으나 환경에 `pyflakes`가 설치되어 있지 않아 실행할 수 없었습니다 (미실행).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699973d2eb34832c922b40316fb3e723)