### PR TITLE
feat: 모니터링 탭에 event/polling 선택 및 이벤트 토큰 입력 추가

### DIFF
--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -264,6 +264,19 @@
                     <div class="form-section">
                         <h3>모니터링 설정</h3>
                         <div class="form-group">
+                            <label for="monitor_mode">감시 방식</label>
+                            <select class="form-control" id="monitor_mode" name="MONITOR_MODE" onchange="toggleMonitorModeFields()">
+                                <option value="event" {% if form_data.get('MONITOR_MODE', 'event') == 'event' %}selected{% endif %}>이벤트 수신 (event)</option>
+                                <option value="polling" {% if form_data.get('MONITOR_MODE') == 'polling' %}selected{% endif %}>주기 스캔 (polling)</option>
+                            </select>
+                            <small class="form-text text-muted">일반적으로 event 모드를 권장합니다. NAS에서 이벤트 전달이 어려운 환경에서는 polling 모드를 사용하세요.</small>
+                        </div>
+                        <div class="form-group" id="event-auth-token-group">
+                            <label for="event_auth_token">이벤트 인증 토큰</label>
+                            <input type="text" class="form-control" id="event_auth_token" name="EVENT_AUTH_TOKEN" value="{{ form_data.get('EVENT_AUTH_TOKEN', '') }}" autocomplete="off">
+                            <small class="form-text text-muted">event 모드에서 `/api/folder-event` 요청의 `X-GShare-Token` 값과 동일해야 합니다.</small>
+                        </div>
+                        <div class="form-group">
                             <label for="cpu_threshold">CPU 사용량 임계치(%)</label>
                             <input type="number" class="form-control" id="cpu_threshold" name="CPU_THRESHOLD" required value="{{ form_data.get('CPU_THRESHOLD', 10) }}" min="1" max="100">
                             <small class="form-text text-muted">이 값 이하로 CPU 사용량이 떨어지면 VM을 종료합니다.</small>
@@ -786,11 +799,31 @@
                 }
             }
         }
+
+        function toggleMonitorModeFields() {
+            const monitorMode = document.getElementById('monitor_mode');
+            const eventAuthTokenGroup = document.getElementById('event-auth-token-group');
+            const eventAuthTokenInput = document.getElementById('event_auth_token');
+
+            if (!monitorMode || !eventAuthTokenGroup || !eventAuthTokenInput) {
+                return;
+            }
+
+            const isEventMode = monitorMode.value === 'event';
+            eventAuthTokenGroup.style.display = isEventMode ? 'block' : 'none';
+
+            if (isEventMode) {
+                eventAuthTokenInput.setAttribute('required', 'required');
+            } else {
+                eventAuthTokenInput.removeAttribute('required');
+            }
+        }
         
         // 페이지 로드 시 초기 버튼 상태 설정
         document.addEventListener('DOMContentLoaded', function() {
             updateNextButtonState('proxmox');
             updateNextButtonState('nfs');
+            toggleMonitorModeFields();
             
             // 설정 파일 접기/펼치기 버튼 아이콘 변경
             $('#configImportExport').on('show.bs.collapse', function () {


### PR DESCRIPTION
### Motivation
- 모니터링 설정 UI에서 `event`/`polling` 전환 및 이벤트 인증 토큰 입력 필드가 없어 설정 접근성이 떨어지는 문제를 해결하기 위해 변경했습니다.

### Description
- `app/templates/landing.html`의 모니터링 섹션에 감시 방식 선택 드롭다운(`MONITOR_MODE`)을 추가했습니다.
- `EVENT_AUTH_TOKEN` 입력 필드를 추가하여 `event` 모드에서 사용할 이벤트 인증 토큰을 설정할 수 있도록 했습니다.
- 클라이언트 스크립트로 `toggleMonitorModeFields()` 함수를 추가해 감시 방식에 따라 토큰 필드를 동적으로 표시/숨김하고 `required` 속성을 설정/해제하도록 처리했습니다.
- 템플릿 내 기존 탭 네비게이션 동작과 연계하여 페이지 로드 시 초기 상태를 반영하도록 호출을 추가했습니다.

### Testing
- `poetry run python -m compileall app` 실행: 성공(completion, 문법 컴파일 통과).
- `poetry run ruff check app` 실행: 실패(기존 코드베이스의 선행 lint 경고/오류로 인한 실패이며 이번 템플릿 변경과 직접 관련 없음).
- `poetry run pytest -q` 실행: 성공(테스트 결과 `9 passed`).
- 애플리케이션을 실행하여 랜딩 페이지 접근 후 모니터링 탭을 확인하는 간단한 브라우저 스크린샷을 생성하여 UI 노출을 검증했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cebfdcf8832c988abb027a185237)