### PR TITLE
이벤트/폴링 초기 상태에서 NFS 폴더 목록 선표시 및 mtime 지연 반영

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -14,6 +14,14 @@ function parseDate(dateStr) {
     }
 }
 
+function toSortableTimestamp(dateStr) {
+    const parsed = parseDate(dateStr);
+    if (!parsed || isNaN(parsed.getTime())) {
+        return Number.NEGATIVE_INFINITY;
+    }
+    return parsed.getTime();
+}
+
 // get_time_ago 함수
 function get_time_ago(timestamp_str) {
     try {
@@ -261,7 +269,7 @@ function updateUI(data) {
     if (data.monitored_folders && Object.keys(data.monitored_folders).length > 0) {
         // mtime 기준으로 정렬된 폴더 배열 생성
         const sortedFolders = Object.entries(data.monitored_folders).sort((a, b) => {
-            return new Date(b[1].mtime) - new Date(a[1].mtime);
+            return toSortableTimestamp(b[1].mtime) - toSortableTimestamp(a[1].mtime);
         });
 
         // 백그라운드로 폴더 목록 처리를 위해 requestAnimationFrame 사용
@@ -898,7 +906,7 @@ function generateFolderListHtml(sortedFolders, showToggleButtons = true, action 
                             <svg class="w-3 h-3 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
-                            <span class="readable-time">${get_time_ago(info.mtime)}</span>
+                            <span class="readable-time">${info.mtime === '-' ? '수정시간 수집 중' : get_time_ago(info.mtime)}</span>
                             <span class="hidden time-string">${info.mtime}</span>
                         </div>
                     </div>
@@ -1003,7 +1011,7 @@ function updateFolderState() {
             if (data.monitored_folders && Object.keys(data.monitored_folders).length > 0) {
                 // mtime 기준으로 정렬된 폴더 배열 생성
                 const sortedFolders = Object.entries(data.monitored_folders).sort((a, b) => {
-                    return new Date(b[1].mtime) - new Date(a[1].mtime);
+                    return toSortableTimestamp(b[1].mtime) - toSortableTimestamp(a[1].mtime);
                 });
 
                 // 대규모 폴더 리스트 처리 최적화
@@ -1206,7 +1214,7 @@ function updateFolderContainer(containerId, folderData, action) {
 
                 if (timeString && readableTime && timeString.innerText !== info.mtime) {
                     timeString.innerText = info.mtime;
-                    readableTime.innerText = getCachedTimeAgo(info.mtime);
+                    readableTime.innerText = info.mtime === '-' ? '수정시간 수집 중' : getCachedTimeAgo(info.mtime);
                     existingItem.dataset.mtime = info.mtime;
                 }
             } else {
@@ -1233,7 +1241,7 @@ function updateFolderContainer(containerId, folderData, action) {
                 }
 
                 // 캐시된 시간 가져오기
-                const cachedTimeAgo = getCachedTimeAgo(info.mtime);
+                const cachedTimeAgo = info.mtime === '-' ? '수정시간 수집 중' : getCachedTimeAgo(info.mtime);
 
                 newItem.innerHTML = `
                     <div class="flex-1 overflow-hidden">


### PR DESCRIPTION
### Motivation
- 이벤트 모드 진입 시 수정시간이 아직 수집되지 않아 메인 페이지에 폴더가 없게 보이는 문제를 해결하기 위해 변경했습니다.
- 폴링 모드에서도 목록을 우선 표시하고, 이후 수정시간(mtime) 수집 결과로 화면이 갱신되도록 개선하려는 의도입니다.

### Description
- `FolderMonitor`에 `_list_subfolders_without_mtime()`를 추가해 `find`로 하위 폴더 목록을 mtime 없이 먼저 가져오도록 했고, `_folder_list_cache`와 짧은 TTL을 두어 호출 빈도를 제어합니다 (파일: `app/main.py`).
- `get_monitored_folders()`를 확장해 `previous_mtimes`에 없는 폴더도 목록에 포함시키고, mtime이 수집되지 않은 항목은 `mtime: '-'`으로 내려주도록 변경했습니다 (파일: `app/main.py`).
- 프론트엔드 정렬 로직을 `toSortableTimestamp()`로 보강해 `mtime: '-'` 항목도 안전하게 정렬되도록 했고, mtime 미수집 상태는 UI에 `수정시간 수집 중`으로 표시하도록 변경했습니다 (파일: `app/static/scripts.js`).
- 변경은 이벤트 모드에서 폴더가 보이지 않던 현상을 완화하고, 폴링 모드에서는 목록 우선 표시 후 비동기적으로 mtime이 반영되게 합니다.

### Testing
- `python -m compileall app`를 실행해 코드 컴파일 검증을 수행했고 성공했습니다.
- `ruff check app`를 실행했으나 기존 코드베이스의 선행 lint 이슈들(프로젝트 내 다른 파일의 unused import, bare except 등)로 실패했으며 이 PR의 변경과 직접 관계없는 기존 경고들입니다.
- `pytest -q`를 실행해 기존 테스트 스위트가 모두 통과함을 확인했습니다 (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d3dbf34c832c82ad1a254158adc9)