### PR TITLE
fix: 폴더 목록 조회 시 embedded null byte 오류 방지

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -455,7 +455,7 @@ class FolderMonitor:
             '-prune',
             '-o',
             '-type', 'd',
-            '-printf', '%P\0'
+            '-printf', r'%P\0'
         ]
 
         try:


### PR DESCRIPTION
### Motivation
- `find -printf '%P\0'` 인자가 Python 문자열 단계에서 실제 NUL 바이트로 해석되어 `embedded null byte` 오류가 발생하던 문제를 해결하기 위한 변경입니다.

### Description
- `app/main.py`에서 `'-printf', '%P\0'`을 `'-printf', r'%P\0'`로 변경해 Python이 문자열에 NUL 문자를 삽입하지 않도록 했습니다.
- 회귀 방지를 위해 `test_folder_monitor_scan.py`에 `_list_subfolders_without_mtime()`가 `find` 명령에 `r'%P\0'` 형태로 인자를 전달하는지 검증하는 단위 테스트를 추가했습니다.
- 테스트 파일의 import 순서 경고(E402)를 무시하기 위해 해당 `from main import FolderMonitor` 라인에 `# noqa: E402` 주석을 추가했습니다.

### Testing
- `poetry run python -m compileall app test_folder_monitor_scan.py` 는 성공적으로 컴파일되었습니다.
- 린트 검사(`poetry run ruff check app/main.py test_folder_monitor_scan.py`)에서 저장소 내 기존의 선행 린트 이슈(미사용 import/변수 등)가 보고되었으나 변경 범위와 직접 관련된 오류는 아닙니다.
- `poetry run pytest -q` 로 전체 테스트를 실행한 결과 모든 테스트가 통과하여 `10 passed`를 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d9c4ef58832c874727a9fc2050e3)