### PR TITLE
fix: NFS 마운트 판별 안정화 및 폴더 목록 조회에서 find 제거

### DIFF
--- a/test_folder_monitor_scan.py
+++ b/test_folder_monitor_scan.py
@@ -11,7 +11,7 @@ sys.modules['web_server'] = MagicMock()
 sys.modules['transcoder'] = MagicMock()
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app'))
-from main import FolderMonitor
+from main import FolderMonitor, _is_nfs_mount_present  # noqa: E402
 
 
 class DummyConfig:
@@ -44,6 +44,32 @@ class TestFolderMonitorFindFallback(unittest.TestCase):
             self.assertIn('A', result)
             self.assertIn('B/C', result)
             self.assertEqual(mock_run.call_count, 2)
+
+
+class TestFolderMonitorListSubfolders(unittest.TestCase):
+    @patch('main.SMBManager')
+    @patch('main.FolderMonitor._get_nfs_ownership', return_value=(1000, 1000))
+    def test_list_subfolders_uses_scandir_and_filters_hidden_dirs(self, _mock_ownership, _mock_smb):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, 'alpha'))
+            os.makedirs(os.path.join(root, 'alpha', 'beta'))
+            os.makedirs(os.path.join(root, '.hidden'))
+            os.makedirs(os.path.join(root, '@eaDir'))
+
+            monitor = FolderMonitor(DummyConfig(root), MagicMock(), 0.0)
+            result = monitor._list_subfolders_without_mtime()
+
+            self.assertEqual(result, ['alpha', 'alpha/beta'])
+
+
+class TestNfsMountPresence(unittest.TestCase):
+    def test_is_nfs_mount_present_parses_proc_mounts(self):
+        mounts_data = """server:/data /mnt/test nfs4 rw,relatime 0 0\n"""
+
+        with patch('main.os.path.realpath', side_effect=lambda p: p):
+            with patch('builtins.open', unittest.mock.mock_open(read_data=mounts_data)):
+                self.assertTrue(_is_nfs_mount_present('/mnt/test', 'server:/data'))
+                self.assertFalse(_is_nfs_mount_present('/mnt/test', 'server:/other'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- NFS가 실제로 마운트되어 있음에도 UI에서 "마운트 실패"로 보이던 오탐을 줄이기 위해 마운트 판별 방식을 개선했습니다.
- `find -printf '%P\0'` 의존으로 인한 NUL/명령어 의존 이슈를 제거하고 단순 폴더 목록 조회를 더 안전하게 수행하도록 변경했습니다.

### Description
- `app/main.py`에서 `_list_subfolders_without_mtime()`를 `find` 호출 기반에서 `os.scandir` 기반 순회(DFS)로 대체하여 숨김(`.`) 및 `@*` 디렉터리를 제외하면서 재귀적으로 하위 폴더를 수집하도록 구현했습니다.
- `app/main.py`에 `_is_nfs_mount_present(mount_path, nfs_path)` 헬퍼를 추가하여 `/proc/mounts`를 파싱해 `nfs`/`nfs4` 타입, 마운트 대상 경로 및 (선택적) 소스 경로를 검사하도록 변경했습니다.
- `check_nfs_status()`와 `_mount_nfs()`에서 기존 `mount` 출력 문자열 포함 검사 대신 `_is_nfs_mount_present`를 사용하도록 교체해 판별 신뢰도를 높였습니다.
- `app/web_server.py`의 `remount_nfs`에서도 동일한 `/proc/mounts` 기반 판별으로 전/후 상태 확인 로직을 변경했고 동일한 검사 로직을 내부 메서드로 추가했습니다.
- `test_folder_monitor_scan.py`를 수정해 폴더 목록 테스트를 `scandir` 동작(하위 폴더 포함, `.hidden`/`@eaDir` 제외)으로 갱신하고 `/proc/mounts` 파싱 동작을 검증하는 단위 테스트를 추가했습니다.

### Testing
- 빌드(컴파일): `poetry run python -m compileall app test_folder_monitor_scan.py` — 성공했습니다.
- 린트: `poetry run ruff check app/main.py app/web_server.py test_folder_monitor_scan.py` — 저장소 내 기존 선행 린트 이슈(미사용 import/변수, 기존 bare-except 등)가 보고되었으며 변경 범위와 직접 관련된 새 오류는 없습니다.
- 단위테스트: `poetry run pytest -q` — 모든 테스트 통과 (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d9c4ef58832c874727a9fc2050e3)