### PR TITLE
메인 페이지 템플릿 렌더링 오류 및 NFS 상태 표시 개선

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -87,6 +87,7 @@ let logHovered = false;
 let autoScrollLog = true; // 자동 스크롤 상태 변수 추가
 let socket = null; // Socket.IO 객체
 let userScrolled = false; // userScrolled 변수를 전역 변수로 이동
+let monitorMode = 'event';
 
 // state를 콘솔에 로깅하는 함수
 function logStateToConsole(state) {
@@ -217,6 +218,10 @@ function updateUI(data) {
     // check_interval 업데이트
     if (data.check_interval) {
         checkInterval = data.check_interval;
+    }
+
+    if (data.monitor_mode) {
+        monitorMode = data.monitor_mode;
     }
 
     // 필수 요소들 존재 여부 확인 및 업데이트
@@ -433,6 +438,11 @@ window.onload = function () {
     const initialSMBStatus = document.querySelector('.smb-status span').innerText;
     updateSMBStatus(initialSMBStatus);
 
+    const initialMonitorMode = document.body?.dataset?.monitorMode;
+    if (initialMonitorMode) {
+        monitorMode = initialMonitorMode;
+    }
+
     // 초기 NFS 상태에 따라 컨테이너 표시 설정
     const initialNFSStatus = document.querySelector('.nfs-status span').innerText;
     updateNFSStatus(initialNFSStatus);
@@ -642,7 +652,7 @@ function updateNFSStatus(status) {
     const nfsStatusSpan = document.querySelector('.nfs-status span:first-child');
     const statusIcon = document.querySelector('.nfs-status span:last-child');
     const smbPanel = document.querySelector('.smb-status-container').closest('.flex.flex-col');
-    const nfsWarning = document.querySelector('.bg-red-50.text-red-700.p-2.rounded-lg.mb-2.border.border-red-200');
+    const nfsWarning = document.getElementById('nfsWarning');
 
     if (!nfsStatusContainer) {
         console.error('NFS 상태 컨테이너를 찾을 수 없습니다.');
@@ -705,9 +715,13 @@ function updateNFSStatus(status) {
             console.warn('NFS 상태 아이콘을 찾을 수 없습니다.');
         }
 
-        // NFS 경고 메시지 표시
+        // NFS 경고 메시지 표시 (polling 모드에서만 표시)
         if (nfsWarning) {
-            nfsWarning.classList.remove('hidden');
+            if (monitorMode === 'polling') {
+                nfsWarning.classList.remove('hidden');
+            } else {
+                nfsWarning.classList.add('hidden');
+            }
         }
 
         // SMB 패널 비활성화

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,7 +31,7 @@
 	</style>
 </head>
 
-<body class="bg-gray-100 p-4">
+<body class="bg-gray-100 p-4" data-monitor-mode="{{ state.get('monitor_mode', 'event') }}">
 	<div class="max-w-7xl mx-auto">
 		<!-- 상단 헤더 -->
 		<div class="flex items-center justify-between mb-4 p-4 rounded-md text-gray-800">
@@ -91,8 +91,8 @@
 					</div>
 				</div>
 				<!-- NFS 경고 메시지 추가 -->
-				<div
-					class="bg-red-50 text-red-700 p-2 rounded-lg mb-2 border border-red-200 {% if state['nfs_status'] == 'ON' %}hidden{% endif %}">
+				<div id="nfsWarning"
+					class="bg-red-50 text-red-700 p-2 rounded-lg mb-2 border border-red-200 {% if state['nfs_status'] == 'ON' or state.get('monitor_mode', 'event') == 'event' %}hidden{% endif %}">
 					<div class="flex items-center gap-1">
 						<svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
 							stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
### Motivation
- 템플릿에서 `state.get(...)`를 사용하는데 `main_page()`가 `State` 객체를 그대로 전달하여 `'State' object has no attribute 'get'` 예외가 발생한 문제를 해결하기 위함입니다.
- NFS 마운트 상태 경고가 항상 표시되는 경우가 있어 `monitor_mode` 정보를 UI에 전달해 폴백 동작을 제어하려는 의도입니다.
- `/proc/mounts` 기반 NFS 판별에서 호스트명/IP 표기 차이로 인한 오탐을 줄이기 위해 export(콜론 이후 경로) 비교를 허용하려는 목적입니다.

### Description
- `app/web_server.py`의 `main_page()`에서 템플릿으로 전달하는 `state`를 `State` 객체 그대로 넘기지 않고 `to_dict()` 결과로 전달하도록 변경했습니다 (`state=current_state.to_dict()` 등).
- `manager.current_state`가 `None`인 경우 `self._get_default_state()`로 안전하게 fallback 하여 `.to_dict()`를 적용하도록 보완했습니다.
- 템플릿 `app/templates/index.html`에 `data-monitor-mode` 속성을 추가하여 `monitor_mode` 값을 전달하도록 했고, NFS 경고 블록에 `id="nfsWarning"`와 `state.get('monitor_mode', 'event')` 기반의 초기 숨김 로직을 추가했습니다.
- 클라이언트 스크립트 `app/static/scripts.js`에서 `monitorMode`를 `document.body.dataset.monitorMode` 및 소켓 상태로부터 갱신하도록 하고, NFS 경고를 `monitorMode === 'polling'`일 때만 표시하도록 동작을 변경했습니다.
- `/proc/mounts` 기반 NFS 판별 로직을 `app/web_server.py`(및 이전 변경으로 `app/main.py`)에서 보완하여 호스트명/IP 차이에도 export(콜론 이후 경로)가 동일하면 마운트된 것으로 인정하도록 비교 로직을 추가했습니다.

### Testing
- `python -m compileall app` 실행: 성공했습니다.
- `ruff check app` 실행: 실패했으나 이는 저장소에 존재하던 기존 lint 이슈들로 인한 것이며 이번 변경과 직접 관련이 없습니다.
- `pytest -q` 실행: 모든 테스트 통과 (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3a8b7350832cbd9115a11806be85)