### PR TITLE
설정 UI: NFS 감시 옵션을 NFS 탭으로 이동하고 VM 모니터링 설정 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ MIT License
    - `EXCLUDED_DIR_NAMES`(선택): 이벤트 제외 디렉토리명(쉼표 구분), 기본값 `@eaDir`
    - 볼륨: 원본 파일이 생성되는 NAS 경로를 `/watch`로 마운트
 2. NAS에서 `docker compose up -d --build` 실행
-3. GShare 설정 페이지의 모니터링 탭에서
-   - 감시 방식: `이벤트 수신 (event)`
+3. GShare 설정 페이지의 NFS 설정 탭에서
+   - NFS 폴더 감시 방식: `이벤트 수신 (event)`
    - 이벤트 인증 토큰: relay와 동일 값
 
 이후 새 파일 생성/이동 이벤트가 발생하면 해당 폴더명이 GShare로 전달되고 SMB 공유 및 VM 시작이 순차 수행됩니다.

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -243,6 +243,20 @@
                             <div class="form-group">
                                 <label for="folder_size_timeout">폴더 용량 확인 시간 초과(초)</label>
                                 <input type="number" class="form-control" id="folder_size_timeout" name="GET_FOLDER_SIZE_TIMEOUT" required value="{{ form_data.get('GET_FOLDER_SIZE_TIMEOUT', 30) }}">
+                                <small class="form-text text-muted">폴더 용량 계산 1회가 이 시간을 넘기면 해당 계산을 중단합니다. (주기 간격 옵션이 아닙니다)</small>
+                            </div>
+                            <div class="form-group">
+                                <label for="monitor_mode">NFS 폴더 감시 방식</label>
+                                <select class="form-control" id="monitor_mode" name="MONITOR_MODE" onchange="toggleMonitorModeFields()">
+                                    <option value="event" {% if form_data.get('MONITOR_MODE', 'event') == 'event' %}selected{% endif %}>이벤트 수신 (event)</option>
+                                    <option value="polling" {% if form_data.get('MONITOR_MODE') == 'polling' %}selected{% endif %}>주기 스캔 (polling)</option>
+                                </select>
+                                <small class="form-text text-muted">NAS 이벤트 전달이 가능하면 event를 권장합니다. 불가능한 경우 polling 모드로 NFS 폴더를 주기 스캔합니다.</small>
+                            </div>
+                            <div class="form-group" id="event-auth-token-group">
+                                <label for="event_auth_token">이벤트 인증 토큰</label>
+                                <input type="text" class="form-control" id="event_auth_token" name="EVENT_AUTH_TOKEN" value="{{ form_data.get('EVENT_AUTH_TOKEN', '') }}" autocomplete="off">
+                                <small class="form-text text-muted">event 모드에서 `/api/folder-event` 요청의 `X-GShare-Token` 값과 동일해야 합니다.</small>
                             </div>
                             <button type="button" class="btn btn-secondary" onclick="prevTab('proxmox-tab')">이전</button>
                             <button type="button" class="btn btn-primary btn-next" onclick="nextTab('vm-tab')">다음</button>
@@ -267,28 +281,16 @@
                 <!-- 모니터링 설정 -->
                 <div class="tab-pane fade" id="monitoring" role="tabpanel" aria-labelledby="monitoring-tab">
                     <div class="form-section">
-                        <h3>모니터링 설정</h3>
-                        <div class="form-group">
-                            <label for="monitor_mode">감시 방식</label>
-                            <select class="form-control" id="monitor_mode" name="MONITOR_MODE" onchange="toggleMonitorModeFields()">
-                                <option value="event" {% if form_data.get('MONITOR_MODE', 'event') == 'event' %}selected{% endif %}>이벤트 수신 (event)</option>
-                                <option value="polling" {% if form_data.get('MONITOR_MODE') == 'polling' %}selected{% endif %}>주기 스캔 (polling)</option>
-                            </select>
-                            <small class="form-text text-muted">일반적으로 event 모드를 권장합니다. NAS에서 이벤트 전달이 어려운 환경에서는 polling 모드를 사용하세요.</small>
-                        </div>
-                        <div class="form-group" id="event-auth-token-group">
-                            <label for="event_auth_token">이벤트 인증 토큰</label>
-                            <input type="text" class="form-control" id="event_auth_token" name="EVENT_AUTH_TOKEN" value="{{ form_data.get('EVENT_AUTH_TOKEN', '') }}" autocomplete="off">
-                            <small class="form-text text-muted">event 모드에서 `/api/folder-event` 요청의 `X-GShare-Token` 값과 동일해야 합니다.</small>
-                        </div>
+                        <h3>VM 모니터링 설정</h3>
                         <div class="form-group">
                             <label for="cpu_threshold">CPU 사용량 임계치(%)</label>
                             <input type="number" class="form-control" id="cpu_threshold" name="CPU_THRESHOLD" required value="{{ form_data.get('CPU_THRESHOLD', 10) }}" min="1" max="100">
                             <small class="form-text text-muted">이 값 이하로 CPU 사용량이 떨어지면 VM을 종료합니다.</small>
                         </div>
                         <div class="form-group">
-                            <label for="check_interval">CPU 사용량 체크 간격(초)</label>
+                            <label for="check_interval">VM 상태/CPU 체크 간격(초)</label>
                             <input type="number" class="form-control" id="check_interval" name="CHECK_INTERVAL" required value="{{ form_data.get('CHECK_INTERVAL', 60) }}" min="10">
+                            <small class="form-text text-muted">이 간격으로 VM 상태와 CPU를 확인합니다. polling 모드에서는 NFS 폴더 스캔도 같은 간격으로 수행됩니다.</small>
                         </div>
                         <div class="form-group">
                             <label for="threshold_count">임계치 체크 횟수</label>


### PR DESCRIPTION
### Motivation
- UI에서 `MONITOR_MODE`(NFS 감시 방식)와 `CHECK_INTERVAL`의 목적이 혼재되어 사용자가 NFS 폴링 간격과 VM 상태 체크 간격을 혼동하는 문제가 있었습니다.
- NFS 전용 옵션은 NFS 설정에 배치하는 것이 논리적이며, 모니터링 탭은 VM 상태(CPU/종료 규칙) 전용으로 정리할 필요가 있었습니다.
- `폴더 용량 확인 시간 초과`의 의미가 "주기 간격"으로 오해될 여지가 있어 명확히 안내해야 했습니다.

### Description
- 초기 설정(landing) 화면에서 `감시 방식(MONITOR_MODE)`과 `이벤트 인증 토큰(EVENT_AUTH_TOKEN)` 항목을 모니터링 탭에서 NFS 설정 탭으로 이동했습니다 (`app/templates/landing.html`).
- `폴더 용량 확인 시간 초과(GET_FOLDER_SIZE_TIMEOUT)` 항목에 "1회 계산 타임아웃(주기 옵션 아님)"을 안내하는 문구를 추가했습니다 (`app/templates/landing.html`).
- 모니터링 탭 제목을 `VM 모니터링 설정`으로 변경하고 `CHECK_INTERVAL` 라벨을 `VM 상태/CPU 체크 간격`으로 수정했으며, 설명에 polling 모드에서 NFS 스캔도 같은 루프/간격으로 동작함을 명시했습니다 (`app/templates/landing.html`).
- 문서(README.md)의 NAS 이벤트 수신 안내에서 감시 방식 설정 위치를 `모니터링 탭`에서 `NFS 설정 탭`으로 업데이트했습니다 (`README.md`).

### Testing
- `poetry run python -m compileall app`를 실행하여 파이썬 바이트컴파일을 성공적으로 수행했습니다.
- `poetry run ruff check .`는 기존 코드베이스의 선행 lint 이슈(사용하지 않는 import/변수, bare except 등)로 실패했으며 해당 lint 오류들은 본 변경과 무관합니다.
- `poetry run pytest -q`를 실행하여 모든 테스트가 성공적으로 통과했습니다 (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4a2b3710832cbe35b6bf97659982)