### PR TITLE
relay: CREATE/MOVED_TO 포함 이벤트 로그 및 웹훅 결과 로그 개선

### DIFF
--- a/nas-event-relay/README.md
+++ b/nas-event-relay/README.md
@@ -1,0 +1,35 @@
+# NAS Event Relay
+
+`watch-and-notify.sh`는 `inotifywait`로 `WATCH_PATH`를 재귀 감시하고, 파일 변경 이벤트를 GShare 서버로 전달합니다.
+
+## 로그 해석
+
+- 기존에는 `CLOSE_WRITE`일 때만 로그가 찍혀서, `CREATE`/`MOVED_TO` 위주 워크로드에서는 "아무 로그가 없는 것처럼" 보일 수 있었습니다.
+- 현재는 감지된 이벤트마다 `event=<...> path=<...>` 로그를 출력하고, 웹훅 전송 성공/실패도 별도 로그로 남깁니다.
+
+## inotify + Docker 마운트 동작 참고
+
+- **로컬 Linux 파일시스템(ext4/xfs/btrfs) bind mount**는 일반적으로 inotify 이벤트가 정상 전달됩니다.
+- **NFS/CIFS/SMB/FUSE 계열 파일시스템**은 이벤트 전달이 불완전할 수 있습니다.
+  - 특히 "다른 노드/클라이언트에서 발생한 변경"은 커널 이벤트로 올라오지 않아 누락될 수 있습니다.
+- 컨테이너 시작 시 로그에 `fs: <type>`과 경고가 출력되면 이 케이스를 의심해야 합니다.
+
+## 빠른 점검 방법
+
+컨테이너 안에서 직접 테스트하면 inotify 경로 문제를 빠르게 구분할 수 있습니다.
+
+```bash
+# 1) 감시 테스트
+docker exec -it <relay-container> sh -lc 'inotifywait -m -r -e create -e close_write /watch'
+
+# 2) 다른 터미널에서 컨테이너 내부 파일 생성
+docker exec -it <relay-container> sh -lc 'mkdir -p /watch/_probe && echo test > /watch/_probe/a.txt'
+```
+
+- 위 테스트에서 이벤트가 나오면 relay 스크립트/필터 설정을 점검합니다.
+- 위 테스트에서도 이벤트가 안 나오면 마운트된 파일시스템 특성일 가능성이 큽니다.
+
+## 운영 팁
+
+- 파일 생성 주체를 가능하면 **동일 호스트(동일 커널 컨텍스트)**로 맞춥니다.
+- 이벤트 신뢰성이 중요하면 inotify 단독 대신 **주기 스캔(polling) 보조 방식**을 추가하는 것이 안전합니다.

--- a/nas-event-relay/watch-and-notify.sh
+++ b/nas-event-relay/watch-and-notify.sh
@@ -17,6 +17,15 @@ if [[ ! -d "$WATCH_PATH" ]]; then
   exit 1
 fi
 
+FS_TYPE="$(stat -f -c %T "$WATCH_PATH" 2>/dev/null || echo unknown)"
+
+case "$FS_TYPE" in
+  nfs|cifs|smb2|fuseblk|fuse)
+    echo "[warn] WATCH_PATH filesystem type is '$FS_TYPE'."
+    echo "[warn] inotify may miss events created outside this kernel context (e.g. remote/network writes)."
+    ;;
+esac
+
 is_excluded_path() {
   local target="$1"
   local names_csv="$2"
@@ -45,15 +54,15 @@ post_event() {
     curl -fsS -X POST "$GSHARE_EVENT_URL" \
       -H 'Content-Type: application/json' \
       -H "X-GShare-Token: $EVENT_AUTH_TOKEN" \
-      -d "$payload" >/dev/null || true
+      -d "$payload" >/dev/null
   else
     curl -fsS -X POST "$GSHARE_EVENT_URL" \
       -H 'Content-Type: application/json' \
-      -d "$payload" >/dev/null || true
+      -d "$payload" >/dev/null
   fi
 }
 
-echo "Watching recursively: $WATCH_PATH (excluding: $EXCLUDED_DIR_NAMES)"
+echo "Watching recursively: $WATCH_PATH (excluding: $EXCLUDED_DIR_NAMES, fs: $FS_TYPE)"
 
 inotifywait -m -r \
   -e close_write -e moved_to -e create \
@@ -62,9 +71,7 @@ inotifywait -m -r \
     continue
   fi
 
-  if [[ "$event" == *"CLOSE_WRITE"* ]]; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] mtime detected: $changed"
-  fi
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] event=$event path=$changed"
 
   if [[ -d "$changed" ]]; then
     folder="$changed"
@@ -81,5 +88,9 @@ inotifywait -m -r \
     rel="."
   fi
 
-  post_event "$rel"
+  if post_event "$rel"; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] notified folder=$rel"
+  else
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [warn] notify failed folder=$rel"
+  fi
 done


### PR DESCRIPTION
### Motivation
- `inotify` 이벤트가 실제로 들어와도 화면에 로그가 없어 "안되는 것처럼" 보이는 케이스를 줄이기 위해 이벤트 가시성을 개선하려고 했습니다.
- 웹훅 전송 실패가 무시되어 원인 파악이 어려웠기 때문에 전송 결과를 명확히 로그에 남기려고 했습니다.

### Description
- 감지되는 모든 이벤트(`CREATE`, `MOVED_TO`, `CLOSE_WRITE` 등)에 대해 `event=<...> path=<...>` 형식의 로그를 항상 출력하도록 `watch-and-notify.sh`를 변경했습니다.
- 웹훅 전송을 호출한 후 반환값을 확인해 성공일 경우 `notified folder=...`, 실패일 경우 `[warn] notify failed folder=...` 로그를 남기도록 변경했습니다; 이에 따라 `curl` 호출부의 `|| true`를 제거했습니다.
- 스크립트 시작 로그에 파일시스템 타입(`fs: $FS_TYPE`)을 표시하고 NFS/CIFS/FUSE 계열에 대해 경고를 출력하도록 했습니다.
- `nas-event-relay/README.md`에 왜 이전에 로그가 보이지 않았는지와 현재의 로그 동작(이벤트별 로그, 웹훅 성공/실패 로그)을 명시해 문서를 갱신했습니다.

### Testing
- `bash -n nas-event-relay/watch-and-notify.sh`를 실행해 문법 검사는 통과했습니다.
- `pytest -q`를 실행해 자동화된 테스트는 모두 통과했으며 결과는 `13 passed`였습니다.
- `docker build -f nas-event-relay/Dockerfile -t nas-event-relay:test nas-event-relay`는 환경에 `docker`가 없어 실행 불가했습니다.
- `shellcheck nas-event-relay/watch-and-notify.sh`는 환경에 `shellcheck`가 없어 실행 불가했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a69fe08f8832c8775fc1bfdbdb9f8)