### PR TITLE
린트 오류 수정 및 테스트 코드 정리

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,6 @@ from transcoder import Transcoder
 import yaml  # type: ignore
 import traceback
 import urllib3  # type: ignore
-import json  # state를 JSON으로 직렬화하기 위해 추가
 
 # SSL 경고 메시지 비활성화
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -1263,8 +1262,6 @@ def check_config_complete():
         try:
             # config.yaml 파일의 수정 시간
             config_mtime = os.path.getmtime(config_path)
-            config_mtime_str = datetime.fromtimestamp(
-                config_mtime).strftime('%Y-%m-%d %H:%M:%S')
 
             # init_flag 파일의 내용에서 시간 읽기
             with open(init_flag_path, 'r') as f:

--- a/app/mqtt_manager.py
+++ b/app/mqtt_manager.py
@@ -4,8 +4,6 @@ import time
 from typing import Any, Dict, Optional, List
 import paho.mqtt.client as mqtt  # type: ignore
 from config import GshareConfig  # type: ignore
-from datetime import datetime
-import pytz  # type: ignore
 
 class MQTTManager:
     def __init__(self, config: GshareConfig):
@@ -206,7 +204,7 @@ class MQTTManager:
                 if self.connected:
                     availability_topic = f"{self.config.MQTT_TOPIC_PREFIX}/status"
                     self.client.publish(availability_topic, "offline", retain=True)
-            except:
+            except Exception:
                 pass
 
             self.client.loop_stop()

--- a/app/smb_manager.py
+++ b/app/smb_manager.py
@@ -301,7 +301,7 @@ class SMBManager:
             # 심볼릭 링크 제거
             self.cleanup_all_symlinks()
 
-            logging.info(f"SMB 공유 비활성화 성공")
+            logging.info("SMB 공유 비활성화 성공")
             return True
         except Exception as e:
             logging.error(f"SMB 공유 비활성화 실패: {e}")

--- a/app/transcoder.py
+++ b/app/transcoder.py
@@ -4,7 +4,6 @@ import subprocess
 import shlex
 import queue
 import threading
-import time
 from functools import lru_cache
 from typing import Optional, Dict, Any, List, Callable
 from config import GshareConfig  # type: ignore
@@ -556,7 +555,7 @@ class Transcoder:
             return {'completed': 0, 'failed': 0, 'total': 0}
 
         # 진단 로그
-        logging.info(f"=== 수동 스캔 시작 ===")
+        logging.info("=== 수동 스캔 시작 ===")
         logging.info(f"마운트 경로: {mount_path}")
         logging.info(f"경로 존재 여부: {os.path.exists(mount_path)}")
         logging.info(f"규칙 수: {len(self.rules)}")

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -503,7 +503,7 @@ class GshareWebServer:
                 with open(init_flag_path, 'w') as f:
                     f.write(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
-            logging.debug(f"설정 저장 완료 - 설정 완료 페이지로 이동합니다.")
+            logging.debug("설정 저장 완료 - 설정 완료 페이지로 이동합니다.")
             return render_template('setup_complete.html')
 
         except Exception as e:
@@ -836,7 +836,7 @@ class GshareWebServer:
                     # NFS 마운트 해제 시도
                     logging.debug(f"기존 NFS 마운트 해제 시도: {mount_path}")
                     subprocess.run(["umount", "-f", mount_path], stderr=subprocess.PIPE, check=False)
-                    logging.debug(f"NFS 마운트 해제 명령 실행 완료")
+                    logging.debug("NFS 마운트 해제 명령 실행 완료")
                 else:
                     logging.debug(f"NFS가 마운트되어 있지 않음: {mount_path}")
             except Exception as e:
@@ -1147,7 +1147,7 @@ class GshareWebServer:
                     logging.debug(f"기존 마운트 지점에서 테스트: {existing_mount_point}")
                     try:
                         # 기존 마운트 지점에서 읽기 테스트
-                        ls_result = subprocess.run(
+                        subprocess.run(
                             f"ls {existing_mount_point}", shell=True, check=True, capture_output=True, text=True)
                         return jsonify({
                             "status": "success",
@@ -1169,7 +1169,7 @@ class GshareWebServer:
 
                     if result.returncode == 0:
                         try:
-                            ls_result = subprocess.run(
+                            subprocess.run(
                                 f"ls {temp_mount}", shell=True, check=True, capture_output=True, text=True)
                             message = "NFS 연결 테스트 성공: 읽기 권한이 정상입니다."
                             status = "success"
@@ -1190,7 +1190,7 @@ class GshareWebServer:
                     try:
                         subprocess.run(
                             f"umount {temp_mount}", shell=True, check=False)
-                    except:
+                    except Exception:
                         pass
 
             return jsonify({

--- a/benchmark_log_emit.py
+++ b/benchmark_log_emit.py
@@ -1,6 +1,5 @@
 import os
 import time
-import logging
 
 # Mock SocketIO
 class MockSocketIO:
@@ -36,7 +35,6 @@ class OptimizedWebServer:
         try:
             if os.path.exists(self.log_file):
                 file_size = os.path.getsize(self.log_file)
-                mode = 'r'
                 if file_size > self.max_log_size:
                     # Read only the last part
                     with open(self.log_file, 'rb') as file:

--- a/test_smb_manager.py
+++ b/test_smb_manager.py
@@ -9,7 +9,7 @@ sys.modules['yaml'] = MagicMock()
 # Add app directory to path
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app'))
 
-from smb_manager import SMBManager
+from smb_manager import SMBManager  # noqa: E402
 
 class DummyConfig:
     SMB_LINKS_DIR = '/tmp/links'
@@ -211,7 +211,7 @@ class TestSMBManagerCleanup(unittest.TestCase):
         self.config = DummyConfig()
 
         # We need to mock cleanup during __init__ though, otherwise it runs real code
-        with patch('smb_manager.SMBManager.cleanup_all_symlinks') as mock_cleanup:
+        with patch('smb_manager.SMBManager.cleanup_all_symlinks'):
             self.smb_manager = SMBManager(self.config, 1000, 1000)
 
     def tearDown(self):

--- a/test_transcoder.py
+++ b/test_transcoder.py
@@ -15,8 +15,8 @@ sys.path.append(os.getcwd())
 # We need to mock config imports inside transcoder if they fail, but they seem to use config.py which is local.
 # config.py imports yaml, so we mocked it.
 
-from app.transcoder import Transcoder
-from app.config import GshareConfig
+from app.transcoder import Transcoder  # noqa: E402
+from app.config import GshareConfig  # noqa: E402
 
 class TestTranscoderOptimization(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### Motivation
- Ruff가 지적한 미사용 import/변수, 불필요한 f-string, 및 bare `except` 등 린트 오류를 제거해 코드 품질을 개선하고 CI 경고를 해소합니다.
- 테스트 파일의 import 순서 문제(E402)를 최소 변경으로 해소해 테스트 실행 환경을 안정화합니다.

### Description
- 미사용 `json` import 및 미사용 변수 제거 등 다수의 불필요 바인딩을 삭제하여 경고를 제거했습니다 (`app/main.py` 등).
- `except:` 를 `except Exception:`으로 변경해 E722 규칙을 준수하도록 수정했습니다 (`app/mqtt_manager.py`, `app/web_server.py`).
- 불필요한 f-string 접두사 제거 및 미사용 변수 할당을 제거해 가독성과 린트 상태를 개선했습니다 (`app/smb_manager.py`, `app/transcoder.py`, `app/web_server.py`, `benchmark_log_emit.py`).
- 테스트 파일의 모듈 임포트 위치 문제(E402)는 `# noqa: E402` 주석을 추가하거나 불필요한 mock 바인딩을 제거해 정리했습니다 (`test_smb_manager.py`, `test_transcoder.py`).

### Testing
- 빌드 검증으로 `python -m compileall app`를 실행했으며 에러 없이 통과했습니다.
- 린트 검사로 `ruff check .`를 실행해 모든 체크를 통과했습니다.
- 단위 테스트로 `python -m pytest -q`를 실행해 모든 테스트가 성공적으로 통과했습니다 (15 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a967852d0832c88a85c7aabb84db1)