### PR TITLE
초기 상태 동기화 및 초기 폴더 탐색 안내 추가

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -87,12 +87,14 @@ class State:
     check_interval: int
     nfs_mounted: bool = False
     monitor_mode: str = 'event'
+    initial_scan_in_progress: bool = False
 
     def to_dict(self):
         data = asdict(self)
         data['vm_status'] = 'ON' if self.vm_running else 'OFF'
         data['smb_status'] = 'ON' if self.smb_running else 'OFF'
         data['nfs_status'] = 'ON' if self.nfs_mounted else 'OFF'
+        data['initial_scan_in_progress'] = self.initial_scan_in_progress
         return data
 
 
@@ -728,7 +730,8 @@ class GShareManager:
             logging.debug("트랜스코딩 비활성화")
 
         # 상태 업데이트는 initialize() 호출 시 수행
-        self.current_state = None
+        self.initial_scan_in_progress = self.config.MONITOR_MODE == 'polling'
+        self.current_state = self.update_state(update_monitored_folders=False)
         logging.debug("GShareManager 객체 생성됨")
 
     def initialize(self) -> None:
@@ -740,6 +743,8 @@ class GShareManager:
             self.folder_monitor.initialize()
         else:
             logging.info('이벤트 수신 모드 활성화: 폴링 초기 스캔을 생략합니다.')
+
+        self.initial_scan_in_progress = False
         
         # 초기 상태 업데이트
         self.current_state = self.update_state()
@@ -974,7 +979,8 @@ class GShareManager:
                 smb_running=smb_running,
                 check_interval=self.config.CHECK_INTERVAL,
                 nfs_mounted=nfs_mounted,
-                monitor_mode=self.config.MONITOR_MODE
+                monitor_mode=self.config.MONITOR_MODE,
+                initial_scan_in_progress=getattr(self, 'initial_scan_in_progress', False)
             )
             return current_state
         except Exception as e:
@@ -994,7 +1000,8 @@ class GShareManager:
                 monitored_folders={},
                 smb_running=False,
                 check_interval=60,  # 기본값 60초
-                monitor_mode='event'
+                monitor_mode='event',
+                initial_scan_in_progress=False
             )
 
     def monitor(self) -> None:

--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -88,6 +88,7 @@ let autoScrollLog = true; // 자동 스크롤 상태 변수 추가
 let socket = null; // Socket.IO 객체
 let userScrolled = false; // userScrolled 변수를 전역 변수로 이동
 let monitorMode = 'event';
+let initialScanInProgress = false;
 
 // state를 콘솔에 로깅하는 함수
 function logStateToConsole(state) {
@@ -224,6 +225,8 @@ function updateUI(data) {
         monitorMode = data.monitor_mode;
     }
 
+    initialScanInProgress = Boolean(data.initial_scan_in_progress);
+
     // 필수 요소들 존재 여부 확인 및 업데이트
     const elements = {
         lastCheckTimeReadable: document.querySelector('.last-check-time .readable-time'),
@@ -258,6 +261,7 @@ function updateUI(data) {
     if (elements.nfsStatus) {
         updateNFSStatus(data.nfs_status);
     }
+    updateInitialScanNotice(initialScanInProgress);
 
     if (elements.cpuUsage) elements.cpuUsage.innerText = data.cpu_usage + '%';
     if (elements.lowCpuCount) elements.lowCpuCount.innerText = data.low_cpu_count + '/' + data.threshold_count;
@@ -287,6 +291,20 @@ function updateUI(data) {
             updateFolderList([]);
         });
     }
+}
+
+function updateInitialScanNotice(inProgress) {
+    const notice = document.getElementById('nfsScanNotice');
+    const nfsWarning = document.getElementById('nfsWarning');
+    if (!notice) return;
+
+    if (inProgress) {
+        notice.classList.remove('hidden');
+        if (nfsWarning) nfsWarning.classList.add('hidden');
+        return;
+    }
+
+    notice.classList.add('hidden');
 }
 
 // 로그 콘텐츠 업데이트 함수

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -71,6 +71,17 @@
 			<!-- NFS 마운트 상태 패널 -->
 			<div class="border border-gray-200 rounded-md p-2 bg-white flex flex-col max-h-[40vh]">
 				<h3 class="font-medium mb-2">From NAS</h3>
+				<div id="nfsScanNotice"
+					class="bg-blue-50 text-blue-700 p-2 rounded-lg mb-2 border border-blue-200 {% if not state.get('initial_scan_in_progress', False) %}hidden{% endif %}">
+					<div class="flex items-center gap-1">
+						<svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+							stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round"
+								d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
+						</svg>
+						<span class="text-sm font-medium">초기 폴더 탐색 중입니다...</span>
+					</div>
+				</div>
 				<div onclick="remountNFS()" style="cursor: pointer" title="클릭하여 NFS 마운트 재시도"
 					class="flex justify-between bg-gray-50 rounded-lg p-2 border border-gray-200 mb-2 nfs-status-container">
 					<div class="flex items-center gap-1">

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -175,7 +175,8 @@ class GshareWebServer:
             monitored_folders={},
             smb_running=False,
             check_interval=60,
-            monitor_mode='event'
+            monitor_mode='event',
+            initial_scan_in_progress=False
         )
 
     def _get_container_ip(self):


### PR DESCRIPTION
### Motivation
- 웹서버 초기 렌더링 시 `manager.current_state`가 `None`이라 경고가 반복 출력되고 VM/SMB 상태가 잘못 OFF로 보이는 현상을 줄이기 위해 초기 상태를 선초기화하도록 개선했습니다.
- 폴링 모드에서 초기에 폴더 트리 스캔이 진행되는 동안 사용자에게 상태 안내(`폴더 탐색중`)를 보여줘 혼동을 줄이기 위해 UI에 명시적인 안내를 추가했습니다.

### Description
- 상태 모델에 `initial_scan_in_progress: bool` 필드를 추가하고 `State.to_dict()`에 직렬화 항목을 포함하도록 했습니다 (`app/main.py`).
- `GShareManager` 생성 시 `current_state`를 즉시 선초기화하도록 `update_state(update_monitored_folders=False)`를 호출하고, `MONITOR_MODE == 'polling'`일 때 `initial_scan_in_progress`를 `True`로 세팅한 뒤 `initialize()` 완료 시 `False`로 전환하도록 구현했습니다 (`app/main.py`).
- 상태가 초기화되지 않았을 때 반환하는 기본 상태(`GshareWebServer._get_default_state`)에도 새 플래그를 반영해 직렬화/렌더링 일관성을 유지했습니다 (`app/web_server.py`).
- 대시보드의 From NAS 패널에 `초기 폴더 탐색 중입니다...` 배너를 추가하고, 프론트엔드에 `updateInitialScanNotice()` 함수를 추가해 상태값(`initial_scan_in_progress`)에 따라 표시/숨김 및 기존 NFS 경고 토글을 처리하도록 구현했습니다 (`app/templates/index.html`, `app/static/scripts.js`).

### Testing
- `python -m compileall app`를 실행해 파이썬 컴파일 오류가 없음을 확인했습니다 (성공).
- 단위 테스트를 `pytest -q`로 실행해 모든 테스트가 통과했음을 확인했습니다 (`15 passed`).
- 코드 스타일 검사 도구인 `flake8`은 현재 환경에 설치되어 있지 않아 실행하지 못했습니다 (환경 미설치).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a975c2780832cb6f767fb9f05fe1a)