### PR TITLE
fix(ui): 초기 상태 동기화 누락으로 잘못 표시되던 값 수정

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -80,7 +80,7 @@ async function setLogLevel() {
     }
 }
 
-let checkInterval = 120; // 기본값
+let checkInterval = 60; // 기본값
 // 로그 자동 업데이트 상태 변수 추가
 let autoUpdateLog = true;
 let logHovered = false;
@@ -217,8 +217,13 @@ function updateUI(data) {
     logStateToConsole(data);
 
     // check_interval 업데이트
-    if (data.check_interval) {
-        checkInterval = data.check_interval;
+    if (Number.isFinite(Number(data.check_interval))) {
+        checkInterval = Number(data.check_interval);
+    }
+
+    const checkIntervalText = document.getElementById('checkIntervalText');
+    if (checkIntervalText) {
+        checkIntervalText.innerText = checkInterval;
     }
 
     if (data.monitor_mode) {
@@ -1021,23 +1026,7 @@ function updateFolderState() {
     fetch('/update_state')
         .then(response => response.json())
         .then(data => {
-            // VM 상태 업데이트 - 선택자 수정
-            const vmStatusSpan = document.querySelector('.vm-status span:first-child');
-            if (vmStatusSpan) {
-                updateVMStatus(data.vm_status);
-            }
-
-            // SMB 상태 업데이트 - 선택자 수정
-            const smbStatusSpan = document.querySelector('.smb-status span:first-child');
-            if (smbStatusSpan) {
-                updateSMBStatus(data.smb_status);
-            }
-
-            // NFS 상태 업데이트 - 선택자 수정
-            const nfsStatusSpan = document.querySelector('.nfs-status span:first-child');
-            if (nfsStatusSpan) {
-                updateNFSStatus(data.nfs_status);
-            }
+            updateUI(data);
 
             // 백그라운드로 폴더 목록 처리
             if (data.monitored_folders && Object.keys(data.monitored_folders).length > 0) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -57,7 +57,7 @@
 							d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
 					</svg>
 					<span class="text-sm text-gray-500">감시중.. (간격:
-						{{state['check_interval']}}초)</span>
+						<span id="checkIntervalText">{{state['check_interval']}}</span>초)</span>
 				</div>
 				<div
 					class="flex items-center gap-1 font-medium text-sm justify-end last-check-time relative text-gray-500">


### PR DESCRIPTION
### Motivation
- 일부 UI가 서버에서 전달된 상태로 초기화되지 않아 `감시중(간격)`이 기본값으로 보이고 VM 종료 관련 카운트 및 초기 폴더 탐색 배너가 잘못 표시되는 문제를 해결하기 위함이다.

### Description
- 템플릿에 동적으로 갱신 가능한 요소를 추가하여 `감시중.. (간격: ...)`에 `id="checkIntervalText"`를 도입해 런타임에 값을 갱신하도록 변경했다 (`app/templates/index.html`).
- 프론트엔드 기본 `checkInterval` 값을 `120`에서 `60`으로 조정하고 `updateUI()`에서 `check_interval`을 안전하게 숫자로 변환해 반영하도록 수정했다 (`app/static/scripts.js`).
- `updateUI(data)`를 중심으로 상태 갱신을 통합해 `updateFolderState()`가 VM/SMB/NFS 등 일부 필드만 부분 갱신하던 로직을 제거하고 전체 상태 동기화를 재사용하도록 변경해 초기 스캔 표시 및 카운트 누락 문제를 해결했다 (`app/static/scripts.js`).

### Testing
- `python -m compileall app` 실행해 파이썬 컴파일이 정상 동작함을 확인했다; 성공.
- `python -m ruff check app`로 린트 검사를 수행했고 모든 체크가 통과했다; 성공.
- `python -m pytest`로 단위 테스트를 실행했으며 모든 테스트(15개)가 성공적으로 통과했다; 성공.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9d6d6d00832cb58b7cc13e1542f7)