### PR TITLE
초기 상태 접근 오류 방지 및 초기 NFS 스캔 시 빈 폴더 메시지 억제

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -89,6 +89,7 @@ let socket = null; // Socket.IO 객체
 let userScrolled = false; // userScrolled 변수를 전역 변수로 이동
 let monitorMode = 'event';
 let initialScanInProgress = false;
+let hasReceivedStateUpdate = false;
 
 // state를 콘솔에 로깅하는 함수
 function logStateToConsole(state) {
@@ -230,6 +231,7 @@ function updateUI(data) {
         monitorMode = data.monitor_mode;
     }
 
+    hasReceivedStateUpdate = true;
     initialScanInProgress = Boolean(data.initial_scan_in_progress);
 
     // 필수 요소들 존재 여부 확인 및 업데이트
@@ -1072,6 +1074,11 @@ function updateFolderState() {
 
 // 폴더 목록만 업데이트하는 함수로 분리
 function updateFolderList(sortedFolders) {
+    // 초기 상태 수신 전이거나 초기 스캔 중에는 빈 상태 메시지를 노출하지 않음
+    if (!hasReceivedStateUpdate || initialScanInProgress) {
+        return;
+    }
+
     // 폴더 목록이 비어있는 경우
     if (!sortedFolders || sortedFolders.length === 0) {
         document.getElementById('monitoredFoldersContainer').innerHTML = `


### PR DESCRIPTION
### Motivation
- `GShareManager.update_state()`가 `self.current_state` 생성 이전에 호출될 때 `AttributeError`가 발생하여 상태 업데이트에 실패하는 문제를 방지합니다.
- 초기 NFS 폴더 탐색(초기 스캔) 중 프런트엔드에서 잘못하여 즉시 "감시 중인 폴더가 없습니다" 메시지가 노출되는 현상을 개선합니다.

### Description
- `app/main.py`에서 `previous_state = getattr(self, 'current_state', None)`을 도입해 `last_check_time`, `monitored_folders`, `smb_running` 재사용 로직을 `previous_state` 기준으로 안전하게 처리하도록 변경했습니다.
- `app/static/scripts.js`에 상태 수신 플래그 `hasReceivedStateUpdate`를 추가하고 `updateFolderList()`에 가드를 넣어 초기 상태 수신 전 또는 `initialScanInProgress` 동안 빈 폴더 안내를 표시하지 않도록 했습니다.
- 위 변경으로 백엔드의 상태 초기화 안전성과 프런트엔드 초기 렌더 타이밍 동작을 동시에 개선했습니다.

### Testing
- `python -m compileall app` 성공했습니다.
- `ruff check .` (정적 검사) 성공했습니다.
- `pytest -q`에서 모든 테스트가 통과하여 `15 passed`를 기록했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa21e0358832cb94006e32b9dfa58)