### PR TITLE
relay: 시작 로그를 즉시 출력하도록 변경

### DIFF
--- a/nas-event-relay/README.md
+++ b/nas-event-relay/README.md
@@ -6,6 +6,8 @@
 
 - 기존에는 `CLOSE_WRITE`일 때만 로그가 찍혀서, `CREATE`/`MOVED_TO` 위주 워크로드에서는 "아무 로그가 없는 것처럼" 보일 수 있었습니다.
 - 현재는 감지된 이벤트마다 `event=<...> path=<...>` 로그를 출력하고, 웹훅 전송 성공/실패도 별도 로그로 남깁니다.
+
+- 시작 시 `Watching recursively: ...` 로그를 즉시 출력하고, 이어서 `Watch target summary: watch_dirs_total=... watch_dirs_effective=...` 로그로 디렉토리 집계를 출력합니다.
 - 전송은 최대 3회(짧은 간격) 재시도하며, 실패 시 `curl_exit`/`http_code`를 함께 로그로 남깁니다.
   - 예: `curl_exit=7`은 대상 서버 연결 실패(서버 미기동/네트워크 경로 문제)
   - 예: `http_code=500`은 GShare 앱 내부 처리 실패
@@ -36,3 +38,9 @@ docker exec -it <relay-container> sh -lc 'mkdir -p /watch/_probe && echo test > 
 
 - 파일 생성 주체를 가능하면 **동일 호스트(동일 커널 컨텍스트)**로 맞춥니다.
 - 이벤트 신뢰성이 중요하면 inotify 단독 대신 **주기 스캔(polling) 보조 방식**을 추가하는 것이 안전합니다.
+
+## 제외 디렉토리 기본값
+
+- `EXCLUDED_DIR_NAMES` 기본값은 `@eaDir,@*,.*` 입니다.
+- 즉 Synology 메타데이터 폴더(`@eaDir`)뿐 아니라, 이름이 `@`로 시작하는 디렉토리(`@*`)와 숨김 디렉토리(`.*`) 하위 이벤트도 기본적으로 무시합니다.
+- 필요하면 환경변수로 쉼표 구분 목록(와일드카드 허용)을 지정해 동작을 바꿀 수 있습니다.

--- a/nas-event-relay/docker-compose.yml
+++ b/nas-event-relay/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       - WATCH_PATH=/watch
       - GSHARE_EVENT_URL=http://<gshare-host>:5000/api/folder-event
       - EVENT_AUTH_TOKEN=<same-token-as-gshare>
-      - EXCLUDED_DIR_NAMES=@eaDir
+      - EXCLUDED_DIR_NAMES=@eaDir,@*,.*
     volumes:
       - <nas-source-path>:/watch:ro

--- a/nas-event-relay/watch-and-notify.sh
+++ b/nas-event-relay/watch-and-notify.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 WATCH_PATH="${WATCH_PATH:-/watch}"
 GSHARE_EVENT_URL="${GSHARE_EVENT_URL:-}"
 EVENT_AUTH_TOKEN="${EVENT_AUTH_TOKEN:-}"
-# 쉼표(,)로 구분된 디렉토리 이름 목록. 기본값은 Synology 메타데이터 폴더.
-EXCLUDED_DIR_NAMES="${EXCLUDED_DIR_NAMES:-@eaDir}"
+# 쉼표(,)로 구분된 디렉토리 이름/패턴 목록.
+# 기본값은 Synology 메타데이터 폴더(@eaDir) + '@'/'dot' 접두 폴더 전체 제외.
+EXCLUDED_DIR_NAMES="${EXCLUDED_DIR_NAMES:-@eaDir,@*,.*}"
 
 if [[ -z "$GSHARE_EVENT_URL" ]]; then
   echo "GSHARE_EVENT_URL is required" >&2
@@ -28,20 +29,50 @@ esac
 
 is_excluded_path() {
   local target="$1"
-  local names_csv="$2"
+  local patterns_csv="$2"
   local IFS=','
+  local rel segment pattern
+  local -a patterns
 
-  read -ra names <<< "$names_csv"
-  for name in "${names[@]}"; do
-    name="${name//[[:space:]]/}"
-    [[ -z "$name" ]] && continue
+  rel="${target#${WATCH_PATH}/}"
+  if [[ "$rel" == "$target" ]]; then
+    rel="${target#/}"
+  fi
 
-    if [[ "$target" == *"/$name" || "$target" == *"/$name/"* ]]; then
-      return 0
-    fi
+  read -ra patterns <<< "$patterns_csv"
+  IFS='/' read -ra segments <<< "$rel"
+
+  for segment in "${segments[@]}"; do
+    [[ -z "$segment" || "$segment" == "." ]] && continue
+
+    for pattern in "${patterns[@]}"; do
+      pattern="${pattern//[[:space:]]/}"
+      [[ -z "$pattern" ]] && continue
+
+      if [[ "$segment" == $pattern ]]; then
+        return 0
+      fi
+    done
   done
 
   return 1
+}
+
+
+count_watch_targets() {
+  local total=0 included=0
+  local dir
+
+  while IFS= read -r dir; do
+    [[ -z "$dir" ]] && continue
+    total=$((total + 1))
+
+    if ! is_excluded_path "$dir" "$EXCLUDED_DIR_NAMES"; then
+      included=$((included + 1))
+    fi
+  done < <(find "$WATCH_PATH" -type d 2>/dev/null)
+
+  echo "$total|$included"
 }
 
 post_event() {
@@ -80,6 +111,11 @@ post_event() {
 }
 
 echo "Watching recursively: $WATCH_PATH (excluding: $EXCLUDED_DIR_NAMES, fs: $FS_TYPE)"
+
+watch_counts="$(count_watch_targets)"
+watch_total="${watch_counts%%|*}"
+watch_included="${watch_counts##*|}"
+echo "Watch target summary: watch_dirs_total=$watch_total watch_dirs_effective=$watch_included"
 
 inotifywait -m -r \
   -e close_write -e moved_to -e create \


### PR DESCRIPTION
### Motivation

- 대규모 경로에서 초기 디렉토리 집계(`find`)가 완료될 때까지 `Watching recursively...` 로그가 지연되어 즉시 가시성이 없던 문제를 해결하기 위해 변경했습니다.

### Description

- `nas-event-relay/watch-and-notify.sh`에서 `echo "Watching recursively: ..."`를 디렉토리 집계 호출(`count_watch_targets`)보다 먼저 출력하도록 순서를 조정했습니다.
- 디렉토리 집계는 이후 별도 요약 로그(`Watch target summary: watch_dirs_total=... watch_dirs_effective=...`)로 출력되며 집계용 함수 `count_watch_targets()`는 유지됩니다.
- 경로 제외 판정 로직(`is_excluded_path`)를 패턴(쉼표 구분, 세그먼트 비교) 지원으로 개선했고 기본 `EXCLUDED_DIR_NAMES`는 `@eaDir,@*,.*`로 확장했습니다.
- `nas-event-relay/README.md`의 로그 해석 문구를 실제 동작(즉시 시작 로그 + 후속 집계 로그)에 맞게 업데이트했습니다.

### Testing

- `poetry run ruff check .`을 실행해 린트 검사를 통과했습니다 (성공).
- `poetry run pytest -q`로 테스트 스위트를 실행해 모든 테스트가 통과하여 `15 passed`를 획득했습니다 (성공).
- `poetry build`는 패키지 메타구성 문제로 실패했으며 에러는 `No file/folder found for package gshare-manager`였습니다 (실패).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abcc24424832c94871e0be5b435f3)