### PR TITLE
fix: config 로딩 시 MOUNT_PATH 누락으로 인한 초기화 실패 수정

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -166,6 +166,7 @@ class GshareConfig:
             'CPU_THRESHOLD': yaml_config['proxmox']['cpu'].get('threshold') or 10.0,
             'CHECK_INTERVAL': yaml_config['proxmox']['cpu'].get('check_interval') or 60,
             'THRESHOLD_COUNT': yaml_config['proxmox']['cpu'].get('threshold_count') or 3,
+            'MOUNT_PATH': yaml_config['mount'].get('path', '/mnt/gshare'),
             'SHUTDOWN_WEBHOOK_URL': yaml_config['credentials'].get('shutdown_webhook_url', ''),
             'SMB_SHARE_NAME': yaml_config['smb'].get('share_name', 'gshare'),
             'SMB_USERNAME': yaml_config['credentials'].get('smb_username', ''),


### PR DESCRIPTION
### Motivation
- YAML에서 `mount.path`가 없을 때 `GshareConfig` dataclass의 필수 필드인 `MOUNT_PATH`가 `config_dict`에 누락되어 `TypeError: __init__() missing 1 required positional argument: 'MOUNT_PATH'` 예외가 발생하므로 기본값을 보장해 앱 초기화 실패를 방지합니다.

### Description
- `app/config.py`의 `GshareConfig.load_config()`에서 `config_dict`에 `'MOUNT_PATH'` 항목을 추가하고 기본값으로 `'/mnt/gshare'`를 사용하도록 했습니다 (파일 변경: `app/config.py`).

### Testing
- `python -m compileall app`를 실행해 컴파일 에러가 없음을 확인했고 성공했습니다.
- `poetry run ruff check app test_*.py`를 실행해 린트 체크 통과를 확인했습니다.
- `poetry run pytest -q`를 실행했으며 이번 변경과 직접 관련 없는 기존 테스트 3건이 실패했습니다 (`test_folder_monitor_scan.py` 내 FolderMonitor 관련 `_get_nfs_ownership` 패치 관련 실패); 나머지 테스트는 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2d9d8eac832cbc69313f65e9c41b)