### PR TITLE
이벤트 모드: Event relay 상태 표시 및 keep-alive(health) 연동 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ MIT License
 1. NAS에서 `nas-event-relay/docker-compose.yml`의 값을 환경에 맞게 수정
    - `GSHARE_EVENT_URL`: gshare_manager의 `/api/folder-event` 주소
    - `EVENT_AUTH_TOKEN`: GShare 설정의 이벤트 인증 토큰과 동일하게 설정
-   - `EXCLUDED_DIR_NAMES`(선택): 이벤트 제외 디렉토리명(쉼표 구분), 기본값 `@eaDir`
+   - `EXCLUDED_DIR_NAMES`(선택): 이벤트 제외 디렉토리명(쉼표 구분), 기본값 `@eaDir,@*,.*`
+   - `GSHARE_HEALTH_URL`(선택): 이벤트 릴레이 health 신호 전송 주소(기본값 자동 유도)
+   - `HEALTH_INTERVAL_SECONDS`(선택): health 신호 전송 간격(기본 30초)
    - 볼륨: 원본 파일이 생성되는 NAS 경로를 `/watch`로 마운트
 2. NAS에서 `docker compose up -d --build` 실행
 3. GShare 설정 페이지의 NFS 설정 탭에서
@@ -73,6 +75,7 @@ MIT License
    - 이벤트 인증 토큰: relay와 동일 값
 
 이후 새 파일 생성/이동 이벤트가 발생하면 해당 폴더명이 GShare로 전달되고 SMB 공유 및 VM 시작이 순차 수행됩니다.
+또한 relay keep-alive를 기준으로 웹 From NAS 섹션에서 Event relay 상태(ON/OFF)를 확인할 수 있습니다.
 파일 쓰기 완료(`close_write`)로 수정시간(mtime) 변화가 감지되면 relay 컨테이너 로그에 감지 경로를 남깁니다.
 
 > relay는 재귀 감시(`inotifywait -r`)를 사용하며, Synology DSM 메타데이터 디렉토리(기본: `@eaDir`)는 이벤트 전송에서 제외합니다.

--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -254,6 +254,9 @@ function updateUI(data) {
         vmStatus: document.querySelector('.vm-status'),
         smbStatus: document.querySelector('.smb-status'),
         nfsStatus: document.querySelector('.nfs-status'),
+        eventRelayStatus: document.querySelector('.event-relay-status'),
+        eventRelayLastSeen: document.querySelector('.event-relay-last-seen'),
+        eventRelayStatusContainer: document.getElementById('eventRelayStatusContainer'),
         cpuUsage: document.querySelector('.cpu-usage'),
         lowCpuCount: document.querySelector('.low-cpu-count'),
         uptime: document.querySelector('.uptime'),
@@ -279,6 +282,9 @@ function updateUI(data) {
     // NFS 상태 업데이트
     if (elements.nfsStatus) {
         updateNFSStatus(data.nfs_status);
+    }
+    if (elements.eventRelayStatus || elements.eventRelayStatusContainer) {
+        updateEventRelayStatus(data.event_relay_status, data.event_relay_last_seen);
     }
     updateInitialScanNotice(initialScanInProgress);
 
@@ -563,6 +569,49 @@ window.onload = function () {
         startPolling();
     }
 };
+
+
+function updateEventRelayStatus(status, lastSeen) {
+    const relayContainer = document.getElementById('eventRelayStatusContainer');
+    const relayStatusWrap = document.querySelector('.event-relay-status');
+    const relayLastSeen = document.querySelector('.event-relay-last-seen');
+
+    if (relayContainer) {
+        if (monitorMode === 'event') {
+            relayContainer.classList.remove('hidden');
+        } else {
+            relayContainer.classList.add('hidden');
+            return;
+        }
+    }
+
+    if (relayLastSeen) {
+        relayLastSeen.innerText = lastSeen || '-';
+    }
+
+    if (!relayStatusWrap) return;
+
+    const statusBadge = relayStatusWrap.querySelector('span:first-child');
+    const statusIcon = relayStatusWrap.querySelector('span:last-child');
+    if (!statusBadge || !statusIcon) return;
+
+    const resolvedStatus = status || 'UNKNOWN';
+    statusBadge.innerText = resolvedStatus;
+
+    statusBadge.classList.remove('bg-emerald-50', 'text-emerald-700', 'bg-amber-50', 'text-amber-700', 'bg-slate-50', 'text-slate-700');
+    statusIcon.classList.remove('bg-green-500', 'bg-yellow-500', 'bg-gray-400');
+
+    if (resolvedStatus === 'ON') {
+        statusBadge.classList.add('bg-emerald-50', 'text-emerald-700');
+        statusIcon.classList.add('bg-green-500');
+    } else if (resolvedStatus === 'OFF') {
+        statusBadge.classList.add('bg-amber-50', 'text-amber-700');
+        statusIcon.classList.add('bg-yellow-500');
+    } else {
+        statusBadge.classList.add('bg-slate-50', 'text-slate-700');
+        statusIcon.classList.add('bg-gray-400');
+    }
+}
 
 function updateVMStatus(status) {
     const vmStatusContainer = document.querySelector('.vm-status-container');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -85,6 +85,28 @@
 						<span class="text-sm font-medium">초기 폴더 탐색 중입니다...</span>
 					</div>
 				</div>
+				<div id="eventRelayStatusContainer"
+					class="flex justify-between bg-gray-50 rounded-lg p-2 border border-gray-200 mb-2 {% if state.get('monitor_mode', 'event') != 'event' %}hidden{% endif %}">
+					<div class="flex items-center gap-1">
+						<svg class="w-4 h-4 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none"
+							viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round"
+								d="M9 17.25v-10.5m3 10.5v-7.5m3 7.5v-4.5M3.75 3h16.5A2.25 2.25 0 0122.5 5.25v13.5A2.25 2.25 0 0120.25 21H3.75A2.25 2.25 0 011.5 18.75V5.25A2.25 2.25 0 013.75 3z" />
+						</svg>
+						<span class="text-xs text-gray-500">Event relay</span>
+					</div>
+					<div class="flex items-center gap-2">
+						<div class="text-xs text-gray-500 event-relay-last-seen">{{ state.get('event_relay_last_seen', '-') }}</div>
+						<div class="flex items-center font-medium text-sm event-relay-status">
+							<span
+								class="text-right px-2 py-0.5 rounded-full {% if state.get('event_relay_status', 'UNKNOWN') == 'ON' %}bg-emerald-50 text-emerald-700{% elif state.get('event_relay_status', 'UNKNOWN') == 'OFF' %}bg-amber-50 text-amber-700{% else %}bg-slate-50 text-slate-700{% endif %}">
+								{{state.get('event_relay_status', 'UNKNOWN')}}
+							</span>
+							<span
+								class="ml-2 w-3 h-3 rounded-full {% if state.get('event_relay_status', 'UNKNOWN') == 'ON' %}bg-green-500{% elif state.get('event_relay_status', 'UNKNOWN') == 'OFF' %}bg-yellow-500{% else %}bg-gray-400{% endif %}"></span>
+						</div>
+					</div>
+				</div>
 				<div onclick="remountNFS()" style="cursor: pointer" title="클릭하여 NFS 마운트 재시도"
 					class="flex justify-between bg-gray-50 rounded-lg p-2 border border-gray-200 mb-2 nfs-status-container">
 					<div class="flex items-center gap-1">

--- a/nas-event-relay/README.md
+++ b/nas-event-relay/README.md
@@ -2,6 +2,8 @@
 
 `watch-and-notify.sh`는 `inotifywait`로 `WATCH_PATH`를 재귀 감시하고, 파일 변경 이벤트를 GShare 서버로 전달합니다.
 
+- relay는 주기적으로 keep-alive(health) 신호를 전송하며, GShare 웹의 **From NAS > Event relay** 상태가 ON/OFF로 표시됩니다.
+
 ## 로그 해석
 
 - 시작 시 `Watching recursively: ...` 로그를 즉시 출력하고, 이어서 `Watch target summary: watch_dirs_total=... watch_dirs_effective=...` 로그로 디렉토리 집계를 출력합니다.
@@ -41,3 +43,10 @@ docker exec -it <relay-container> sh -lc 'mkdir -p /watch/_probe && echo test > 
 - `EXCLUDED_DIR_NAMES` 기본값은 `@eaDir,@*,.*` 입니다.
 - 즉 Synology 메타데이터 폴더(`@eaDir`)뿐 아니라, 이름이 `@`로 시작하는 디렉토리(`@*`)와 숨김 디렉토리(`.*`) 하위 이벤트도 기본적으로 무시합니다.
 - 필요하면 환경변수로 쉼표 구분 목록(와일드카드 허용)을 지정해 동작을 바꿀 수 있습니다.
+
+
+## Health(keep-alive)
+
+- `GSHARE_HEALTH_URL`(선택): 기본값은 `GSHARE_EVENT_URL`에서 자동 유도한 `/api/event-relay/health` 입니다.
+- `HEALTH_INTERVAL_SECONDS`(선택): keep-alive 전송 간격(기본 30초).
+- health 전송이 끊기면 GShare UI의 Event relay 상태가 일정 시간 후 `OFF`로 바뀝니다.

--- a/nas-event-relay/docker-compose.yml
+++ b/nas-event-relay/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - WATCH_PATH=/watch
       - GSHARE_EVENT_URL=http://<gshare-host>:5000/api/folder-event
       - EVENT_AUTH_TOKEN=<same-token-as-gshare>
+      - GSHARE_HEALTH_URL=http://<gshare-host>:5000/api/event-relay/health
+      - HEALTH_INTERVAL_SECONDS=30
       - EXCLUDED_DIR_NAMES=@eaDir,@*,.*
     volumes:
       - <nas-source-path>:/watch:ro

--- a/nas-event-relay/watch-and-notify.sh
+++ b/nas-event-relay/watch-and-notify.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 WATCH_PATH="${WATCH_PATH:-/watch}"
 GSHARE_EVENT_URL="${GSHARE_EVENT_URL:-}"
 EVENT_AUTH_TOKEN="${EVENT_AUTH_TOKEN:-}"
+GSHARE_HEALTH_URL="${GSHARE_HEALTH_URL:-}"
+HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-30}"
 # 쉼표(,)로 구분된 디렉토리 이름/패턴 목록.
 # 기본값은 Synology 메타데이터 폴더(@eaDir) + '@'/'dot' 접두 폴더 전체 제외.
 EXCLUDED_DIR_NAMES="${EXCLUDED_DIR_NAMES:-@eaDir,@*,.*}"
@@ -11,6 +13,10 @@ EXCLUDED_DIR_NAMES="${EXCLUDED_DIR_NAMES:-@eaDir,@*,.*}"
 if [[ -z "$GSHARE_EVENT_URL" ]]; then
   echo "GSHARE_EVENT_URL is required" >&2
   exit 1
+fi
+
+if [[ -z "$GSHARE_HEALTH_URL" ]]; then
+  GSHARE_HEALTH_URL="${GSHARE_EVENT_URL%/api/folder-event}/api/event-relay/health"
 fi
 
 if [[ ! -d "$WATCH_PATH" ]]; then
@@ -57,6 +63,47 @@ is_excluded_path() {
 
   return 1
 }
+
+
+post_health() {
+  local payload http_code
+  payload='{"status":"alive"}'
+
+  if [[ -n "$EVENT_AUTH_TOKEN" ]]; then
+    http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$GSHARE_HEALTH_URL" \
+      --connect-timeout 2 --max-time 5 \
+      -H 'Content-Type: application/json' \
+      -H "X-GShare-Token: $EVENT_AUTH_TOKEN" \
+      -d "$payload") || return 1
+  else
+    http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$GSHARE_HEALTH_URL" \
+      --connect-timeout 2 --max-time 5 \
+      -H 'Content-Type: application/json' \
+      -d "$payload") || return 1
+  fi
+
+  [[ "$http_code" =~ ^2[0-9][0-9]$ ]]
+}
+
+start_health_loop() {
+  (
+    while true; do
+      if ! post_health; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [warn] health notify failed url=$GSHARE_HEALTH_URL" >&2
+      fi
+      sleep "$HEALTH_INTERVAL_SECONDS"
+    done
+  ) &
+  HEALTH_LOOP_PID=$!
+}
+
+cleanup() {
+  if [[ -n "${HEALTH_LOOP_PID:-}" ]]; then
+    kill "$HEALTH_LOOP_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
 
 
 count_watch_targets() {
@@ -120,6 +167,8 @@ watch_counts="$(count_watch_targets)"
 watch_total="${watch_counts%%|*}"
 watch_included="${watch_counts##*|}"
 echo "Watch target summary: watch_dirs_total=$watch_total watch_dirs_effective=$watch_included"
+start_health_loop
+echo "Health check loop started: every ${HEALTH_INTERVAL_SECONDS}s -> $GSHARE_HEALTH_URL"
 
 inotifywait -m -r \
   -e close_write -e moved_to -e create \


### PR DESCRIPTION
### Motivation
- NAS에서 전달되는 이벤트 릴레이가 주기적으로 접속 상태(keep-alive/health)를 보내면 웹 UI의 From NAS(이벤트 모드)에서 릴레이 상태를 명확히 보여주기 위해 변경했습니다.
- 이벤트 기반 동작에서 릴레이가 오프라인일 때 사용자에게 시각적 신호를 주고, 릴레이에서 직접 생존 신호를 받아 상태를 최신화하기 위함입니다.

### Description
- 상태 모델(`State`)에 `event_relay_status`와 `event_relay_last_seen` 필드를 추가하여 상태 응답에 릴레이 상태 및 마지막 신호 시각을 포함하도록 했습니다 (`app/main.py`).
- `GShareManager`에 마지막 릴레이 신호 타임스탬프와 타임아웃 로직을 추가하고, 폴더 이벤트 수신 시 릴레이 생존 표시를 갱신하는 `mark_event_relay_alive()`를 호출하도록 했습니다 (`app/main.py`).
- 웹 서버에 릴레이의 keep-alive 수신용 엔드포인트 `/api/event-relay/health`을 추가했고, 기존 이벤트 토큰 검증 로직과 동일하게 인증 후 상태 브로드캐스트 및 MQTT 발행을 수행하도록 구현했습니다 (`app/web_server.py`).
- 웹 UI의 From NAS 패널에 Event relay 카드(상태 배지, 신호 시각)를 추가하고, 클라이언트 스크립트에서 서버 상태의 `event_relay_status`/`event_relay_last_seen`를 반영해 실시간으로 갱신하도록 변경했습니다 (`app/templates/index.html`, `app/static/scripts.js`).
- NAS 측 relay 스크립트(`nas-event-relay/watch-and-notify.sh`)에 주기적 health 전송 루프를 추가하고(`GSHARE_HEALTH_URL`, `HEALTH_INTERVAL_SECONDS` 환경변수 도입), 기본값 자동 유도 및 compose 예시/문서 업데이트를 포함했습니다 (`nas-event-relay/*`, `README.md`).

### Testing
- `poetry run python -m compileall app nas-event-relay`를 실행하여 파이썬 파일들이 컴파일 가능한지 확인했고 성공했습니다.
- 정적 검사 `poetry run ruff check .`를 실행했고 모든 체크가 통과했습니다.
- 단위 테스트 `poetry run pytest -q`를 실행했으며 기존 테스트 중 3건이 실패했습니다; 실패 원인은 이번 변경과 무관하게 테스트에서 기대하는 `FolderMonitor` 내부 보조 메서드(`_scan_folders_hybrid`, `_list_subfolders_without_mtime`)가 존재하지 않아 발생한 `AttributeError`입니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3d93c98c832cbe8917e8922cf645)