### PR TITLE
이벤트 모드: NAS relay 헬스(heartbeat) 수신 및 From NAS 패널에 상태 표시 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ MIT License
 1. NAS에서 `nas-event-relay/docker-compose.yml`의 값을 환경에 맞게 수정
    - `GSHARE_EVENT_URL`: gshare_manager의 `/api/folder-event` 주소
    - `EVENT_AUTH_TOKEN`: GShare 설정의 이벤트 인증 토큰과 동일하게 설정
-   - `EXCLUDED_DIR_NAMES`(선택): 이벤트 제외 디렉토리명(쉼표 구분), 기본값 `@eaDir`
+   - `EXCLUDED_DIR_NAMES`(선택): 이벤트 제외 디렉토리명(쉼표 구분), 기본값 `@eaDir,@*,.*`
+   - `HEARTBEAT_INTERVAL_SECONDS`(선택): 릴레이 헬스 신호 전송 주기(초), 기본값 `30`
    - 볼륨: 원본 파일이 생성되는 NAS 경로를 `/watch`로 마운트
 2. NAS에서 `docker compose up -d --build` 실행
 3. GShare 설정 페이지의 NFS 설정 탭에서
    - NFS 폴더 감시 방식: `이벤트 수신 (event)`
    - 이벤트 인증 토큰: relay와 동일 값
 
-이후 새 파일 생성/이동 이벤트가 발생하면 해당 폴더명이 GShare로 전달되고 SMB 공유 및 VM 시작이 순차 수행됩니다.
+이후 새 파일 생성/이동 이벤트가 발생하면 해당 폴더명이 GShare로 전달되고 SMB 공유 및 VM 시작이 순차 수행됩니다. 또한 relay는 주기적으로 헬스(heartbeat)를 전송해, 웹 UI의 From NAS 패널에서 이벤트 릴레이 상태(ON/OFF/UNKNOWN)와 마지막 신호 시간을 확인할 수 있습니다.
 파일 쓰기 완료(`close_write`)로 수정시간(mtime) 변화가 감지되면 relay 컨테이너 로그에 감지 경로를 남깁니다.
 
 > relay는 시작 시 계산한 디렉토리 목록(`watch_dirs_effective`)만 감시하며, 재귀 `-r` 옵션은 사용하지 않습니다.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -105,6 +105,31 @@
 					</div>
 				</div>
 				<!-- NFS 경고 메시지 추가 -->
+
+				<div id="relayStatusContainer"
+					class="flex justify-between bg-gray-50 rounded-lg p-2 border border-gray-200 mb-2 {% if state.get('monitor_mode', 'event') != 'event' %}hidden{% endif %}">
+					<div class="flex items-center gap-1">
+						<svg class="w-4 h-4 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none"
+							viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round"
+								d="M8.288 15.038a5.25 5.25 0 117.424 0M5.106 11.856a9.75 9.75 0 0113.788 0M1.924 8.674a14.25 14.25 0 0120.152 0M12 18.75h.008v.008H12v-.008z" />
+						</svg>
+						<span class="text-xs text-gray-500">Event relay</span>
+					</div>
+					<div class="flex items-center font-medium text-sm relay-status">
+						<span id="relayStatusBadge"
+							class="text-right px-2 py-0.5 rounded-full {% if state.get('relay_status', 'UNKNOWN') == 'ON' %}bg-emerald-50 text-emerald-700{% elif state.get('relay_status', 'UNKNOWN') == 'OFF' %}bg-red-50 text-red-700{% else %}bg-slate-50 text-slate-700{% endif %}">
+							{{state.get('relay_status', 'UNKNOWN')}}
+						</span>
+						<span id="relayStatusDot"
+							class="ml-2 w-3 h-3 rounded-full {% if state.get('relay_status', 'UNKNOWN') == 'ON' %}bg-green-500{% elif state.get('relay_status', 'UNKNOWN') == 'OFF' %}bg-red-500{% else %}bg-gray-400{% endif %}"></span>
+					</div>
+				</div>
+				<div id="relayLastSeen"
+					class="text-xs text-gray-500 mb-2 {% if state.get('monitor_mode', 'event') != 'event' %}hidden{% endif %}">
+					마지막 신호: <span class="relay-last-seen-readable">{{state.get('relay_last_seen', '-')}}</span>
+					<span class="relay-last-seen-string hidden">{{state.get('relay_last_seen', '-')}}</span>
+				</div>
 				<div id="nfsWarning"
 					class="bg-red-50 text-red-700 p-2 rounded-lg mb-2 border border-red-200 {% if state['nfs_status'] == 'ON' or state.get('monitor_mode', 'event') == 'event' %}hidden{% endif %}">
 					<div class="flex items-center gap-1">

--- a/nas-event-relay/README.md
+++ b/nas-event-relay/README.md
@@ -8,6 +8,7 @@
 - relay는 `watch_dirs_effective` 목록만 감시합니다(재귀 `-r` 미사용).
 - 새 디렉토리 생성이 감지되면 목록 갱신 필요 상태로 표시하고, **하루 1회(기본 86400초)** 목록을 재계산해 감시 대상을 갱신합니다. (`WATCHLIST_REFRESH_INTERVAL_SECONDS`로 조정 가능)
 - 전송은 최대 3회(짧은 간격) 재시도하며, 실패 시 `curl_exit`/`http_code`를 함께 로그로 남깁니다.
+- 기본 30초 간격(`HEARTBEAT_INTERVAL_SECONDS`)으로 헬스 신호를 전송해 GShare UI에서 relay 생존 상태를 표시할 수 있습니다.
   - 예: `curl_exit=7`은 대상 서버 연결 실패(서버 미기동/네트워크 경로 문제)
   - 예: `http_code=500`은 GShare 앱 내부 처리 실패
 

--- a/nas-event-relay/docker-compose.yml
+++ b/nas-event-relay/docker-compose.yml
@@ -8,5 +8,6 @@ services:
       - GSHARE_EVENT_URL=http://<gshare-host>:5000/api/folder-event
       - EVENT_AUTH_TOKEN=<same-token-as-gshare>
       - EXCLUDED_DIR_NAMES=@eaDir,@*,.*
+      - HEARTBEAT_INTERVAL_SECONDS=30
     volumes:
       - <nas-source-path>:/watch:ro


### PR DESCRIPTION
### Motivation
- NAS의 이벤트 릴레이가 주기적 헬스/heartbeat 신호를 보낼 수 있으므로, 이벤트 모드일 때 웹 UI의 From NAS 섹션에 릴레이 생존 상태를 표시하고 헬스 신호를 받아 상태를 갱신하도록 만들기 위함입니다.
- NAS 쪽 relay가 주기적으로 신호를 보내면 앱에서 이를 감지해 사용자에게 ON/OFF/UNKNOWN 및 마지막 수신 시간을 보여주고, 폴더 이벤트와 구분해 처리하려는 목적입니다.

### Description
- 상태 모델에 `relay_status`와 `relay_last_seen` 필드를 추가하고 `State` 응답에 포함되도록 했습니다 (`State.relay_status`, `State.relay_last_seen`).
- `GShareManager`에 `touch_event_relay()`와 `_get_event_relay_status()`를 추가해 릴레이의 마지막 수신 시각을 기록하고 event 모드 기준으로 `ON`/`OFF`/`UNKNOWN` 상태를 계산하도록 구현했습니다.
- `/api/folder-event` 엔드포인트를 개선해 `health`/`heartbeat`(폴더 없이 전송 가능)를 수신하면 `touch_event_relay()`를 호출하고 전체 스캔 없이 상태만 갱신해 UI에 반영하도록 변경했습니다 (`app/web_server.py`).
- 메인 대시보드의 From NAS 패널에 이벤트 릴레이 배지와 마지막 신호 표시를 추가하고 템플릿과 CSS 클래스/숨김 로직을 구현했습니다 (`app/templates/index.html`).
- 프론트엔드에 `updateRelayStatus()` 함수를 추가하고 실시간 상태 업데이트 및 1초 주기 상대시간 갱신 루프에서 relay 마지막 수신 시간을 갱신하도록 했습니다 (`app/static/scripts.js`).
- NAS relay 스크립트 `watch-and-notify.sh`에 주기적 heartbeat 전송 기능을 추가하고 환경변수 `HEARTBEAT_INTERVAL_SECONDS`(기본 30초)를 도입했으며, `docker-compose.yml` 예시와 문서들을 업데이트했습니다 (`nas-event-relay/watch-and-notify.sh`, `nas-event-relay/docker-compose.yml`, `README.md`, `nas-event-relay/README.md`).

### Testing
- 의존성/빌드 체크로 `poetry install` 및 `poetry run python -m compileall app nas-event-relay`를 실행했으며 컴파일은 성공했습니다.
- 정적 분석으로 `poetry run ruff check .`를 실행했으며 모든 린트 검사가 통과했습니다.
- 단위 테스트 실행 `poetry run pytest -q`에서는 `test_folder_monitor_scan.py`의 3개 테스트가 실패했는데, 실패 원인은 해당 테스트들이 참조하는 내부 유틸 메서드(`_scan_folders_hybrid`, `_list_subfolders_without_mtime` 등)가 현재 코드 베이스에 존재하지 않아 발생한 것입니다(기능 변경과 직접적 관련 없음).
- relay 스크립트 문법 검증 `bash -n nas-event-relay/watch-and-notify.sh`는 성공했으며, Playwright로 웹 UI 스크린샷을 시도했으나 애플리케이션 서버가 미기동 상태라 `ERR_EMPTY_RESPONSE`로 캡처에 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c632d24ac832cbddca1f2ca9b0df0)