### PR TITLE
event 모드에서도 초기 폴더 스캔을 항상 수행하도록 변경

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -541,7 +541,8 @@ class GShareManager:
             logging.debug("트랜스코딩 비활성화")
 
         # 상태 업데이트는 initialize() 호출 시 수행
-        self.initial_scan_in_progress = self.config.MONITOR_MODE == 'polling'
+        # 모니터링 방식과 무관하게 초기 스캔은 항상 수행하므로 기본값은 False로 둔다.
+        self.initial_scan_in_progress = False
         logging.info(
             f"초기 상태 계산 시작 (monitor_mode={self.config.MONITOR_MODE}, initial_scan_in_progress={self.initial_scan_in_progress})")
         self.current_state = self.update_state(update_monitored_folders=False)
@@ -552,15 +553,11 @@ class GShareManager:
         """GShareManager 초기화 수행 (무거운 작업 포함)"""
         logging.debug("GShareManager 초기화 작업 시작...")
 
-        # FolderMonitor 초기화 (polling 모드는 비동기 초기 스캔으로 실행)
-        if self.config.MONITOR_MODE == 'polling':
-            logging.info('폴링 모드 초기 스캔을 백그라운드에서 시작합니다.')
-            self.initial_scan_in_progress = True
-            self._initial_scan_thread = threading.Thread(target=self._run_initial_scan_async, daemon=True)
-            self._initial_scan_thread.start()
-        else:
-            logging.info('이벤트 수신 모드 활성화: 폴링 초기 스캔을 생략합니다.')
-            self.initial_scan_in_progress = False
+        # FolderMonitor 초기화 (모든 모드에서 비동기 초기 스캔 실행)
+        logging.info(f'{self.config.MONITOR_MODE} 모드 초기 스캔을 백그라운드에서 시작합니다.')
+        self.initial_scan_in_progress = True
+        self._initial_scan_thread = threading.Thread(target=self._run_initial_scan_async, daemon=True)
+        self._initial_scan_thread.start()
 
         # 초기 상태 업데이트
         self.current_state = self.update_state()


### PR DESCRIPTION
### Motivation
- 이벤트 기반(`event`) 모드에서 초기 폴더 스캔을 건너뛰면 초기 `monitored_folders`와 심볼릭 링크 상태가 누락되어 UI와 동작이 일관되지 않을 수 있어 모든 모드에서 초기 스캔을 수행하도록 변경했습니다.

### Description
- `GShareManager.__init__()`에서 `initial_scan_in_progress`의 기본값을 모드 기반이 아닌 `False`로 변경해 상태 플래그 의미를 정리했습니다.
- `GShareManager.initialize()`는 이제 모드와 무관하게 비동기 초기 스캔 스레드(`_run_initial_scan_async`)를 항상 시작하도록 변경되었습니다 (로그 메시지도 모드 공통 방식으로 정리됨). 
- 초기 스캔 완료 후 기존 흐름대로 상태를 갱신하도록 유지했습니다 (`_run_initial_scan_async`에서 `update_state(update_monitored_folders=True)` 호출). 
- 회귀 방지를 위해 `event` 모드에서도 초기 스캔 스레드가 시작되는지 검증하는 단위 테스트를 추가했습니다 (`test_folder_monitor_scan.py`).

### Testing
- `poetry run ruff check .`를 실행해 린트 검사를 통과했습니다 (성공).
- `poetry run python -m unittest test_folder_monitor_scan.TestGShareManagerInitialize` 단일 테스트를 실행해 새로 추가한 초기화 동작 검증 테스트가 통과했습니다 (성공).
- 전체 테스트 스위트(`poetry run python -m unittest`) 실행 시 기존의 `_scan_folders_hybrid` 및 `_list_subfolders_without_mtime` 관련 테스트 3건이 실패하여 전체는 실패로 보고되었으나 해당 실패는 이번 변경과 직접 관련 없는 기존 이슈로 보입니다 (실패).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7530fc88832c853819c96672029b)