### PR TITLE
relay coproc를 FIFO(named pipe)으로 교체하고 watch 등록 로깅 추가

### DIFF
--- a/nas-event-relay/README.md
+++ b/nas-event-relay/README.md
@@ -1,10 +1,12 @@
 # NAS Event Relay
 
 `watch-and-notify.sh`는 시작 시 감시 대상 디렉토리 목록을 계산한 뒤, 해당 목록만 `inotifywait`로 감시하고 파일 변경 이벤트를 GShare 서버로 전달합니다.
+내부 이벤트 수집은 `coproc` 대신 named pipe(FIFO) 기반으로 동작합니다.
 
 ## 로그 해석
 
 - 시작 시 `Inotify limits: ...` 로그와 `Watching directory list: ...`, `Watch target summary: ...` 로그를 출력합니다.
+- watch 등록 과정은 `[watch-register]` 접두 로그로 상세 출력됩니다. (watchlist 생성/샘플, inotify 시작 PID, inotify 원시 메시지 등)
 - relay는 `watch_dirs_effective` 목록만 감시합니다(재귀 `-r` 미사용).
 - 새 디렉토리 생성이 감지되면 목록 갱신 필요 상태로 표시하고, **하루 1회(기본 86400초)** 목록을 재계산해 감시 대상을 갱신합니다. (`WATCHLIST_REFRESH_INTERVAL_SECONDS`로 조정 가능)
 - 전송은 최대 3회(짧은 간격) 재시도하며, 실패 시 `curl_exit`/`http_code`를 함께 로그로 남깁니다.


### PR DESCRIPTION
### Motivation
- 이벤트 릴레이가 루프 진입 전에 블록되고 하트비트가 찍히지 않는 문제를 해결하기 위해 `coproc` 대신 named pipe(FIFO)를 사용하고 watch 등록 과정을 상세히 로깅하도록 변경했습니다.

### Description
- `nas-event-relay/watch-and-notify.sh`에서 `coproc` 기반 `inotifywait` 파이프라인을 제거하고 `mkfifo`로 생성한 FIFO에 `inotifywait` 출력을 리다이렉트하고 FD `3`로 읽도록 변경했습니다.
- 이벤트 파이프 생성/정리(`mkfifo`, `exec 3<>` 및 `cleanup`에서 fd/pipe 제거)와 `inotifywait` 재시작 시 PID 및 파이프 경로를 `[watch-register]` 로그로 남기도록 추가했습니다.
- watchlist 빌드 시 샘플 항목(`head -n 5`)과 카운트 정보를 `[watch-register]` 접두 로그로 출력하도록 로깅을 확장했습니다.
- `nas-event-relay/README.md`를 갱신하여 FIFO 기반 이벤트 수집 및 새로 추가된 `[watch-register]` 로그 항목을 문서화했습니다.

### Testing
- `bash -n nas-event-relay/watch-and-notify.sh` 명령으로 스크립트 문법 검사를 수행했고 통과했습니다.
- `pytest -q` 를 실행했으며 변경과 무관한 `test_folder_monitor_scan.py` 관련 3건의 테스트 실패로 전체 테스트는 실패했습니다 (3 failed, 13 passed).
- `poetry build` 는 저장소가 non-package 모드여서 빌드가 불가해 실패했습니다.
- `docker build -t nas-event-relay-test ./nas-event-relay` 는 해당 실행환경에 `docker` CLI가 없어 시도 불가했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c81e598b0832ca2bba759f2e48b5b)