### PR TITLE
이벤트 모드에서 중복 심볼릭 링크 생성 시 File exists 오류 방지

### DIFF
--- a/app/smb_manager.py
+++ b/app/smb_manager.py
@@ -606,15 +606,34 @@ class SMBManager:
         """
         try:
             source_path = os.path.join(self.config.MOUNT_PATH, subfolder)
-            link_path = os.path.join(
-                self.links_dir, subfolder.replace(os.sep, '_'))
+            link_name = subfolder.replace(os.sep, '_')
+            link_path = os.path.join(self.links_dir, link_name)
 
-            # 이미 존재하는 링크 제거
-            if os.path.exists(link_path):
+            # 이미 동일한 심볼릭 링크가 있으면 재생성하지 않고 성공으로 처리
+            if os.path.islink(link_path):
+                try:
+                    if os.readlink(link_path) == source_path:
+                        self._active_links.add(link_name)
+                        logging.debug(f"이미 활성화된 심볼릭 링크를 재사용합니다: {link_path}")
+                        return True
+                except OSError:
+                    # readlink 실패 시 아래 재생성 로직으로 진행
+                    pass
+
+            # 링크/파일이 이미 존재하면 제거 (깨진 symlink 대응을 위해 lexists 사용)
+            if os.path.lexists(link_path):
                 os.remove(link_path)
 
             # 심볼릭 링크 생성
-            os.symlink(source_path, link_path)
+            try:
+                os.symlink(source_path, link_path)
+            except FileExistsError:
+                # 이벤트가 짧은 간격으로 중복 도착한 경쟁 상태일 수 있음
+                if os.path.islink(link_path) and os.readlink(link_path) == source_path:
+                    self._active_links.add(link_name)
+                    logging.debug(f"동일 링크가 이미 생성되어 재사용합니다: {link_path}")
+                    return True
+                raise
             
             # SMB 사용자의 소유권으로 변경
             try:
@@ -631,7 +650,7 @@ class SMBManager:
             except Exception as e:
                 logging.warning(f"심볼릭 링크 소유권 변경 실패 ({link_path}): {e}")
 
-            self._active_links.add(subfolder.replace(os.sep, "_"))
+            self._active_links.add(link_name)
             logging.info(f"심볼릭 링크 생성됨: {link_path} -> {source_path}")
             return True
         except Exception as e:


### PR DESCRIPTION
### Motivation
- 이벤트 모드에서 동일 폴더에 대한 이벤트가 짧은 시간에 중복으로 들어오면 `os.symlink`가 `File exists` 오류를 낳아 에러 로그가 쌓이고 불필요한 실패 처리로 이어집니다.

### Description
- `SMBManager.create_symlink`를 개선해 이미 같은 타깃을 가리키는 심볼릭 링크가 있으면 재생성하지 않고 성공으로 처리하도록 구현했습니다.
- 링크 존재 판별 시 `os.path.exists` 대신 깨진 심볼릭 링크도 감지 가능한 `os.path.lexists`를 사용해 안전하게 제거/재생성하도록 변경했습니다.
- `os.symlink`가 `FileExistsError`를 던지는 경쟁 상태에서는 실제로 동일 타깃인지 확인하고 동일하면 정상 성공으로 처리하도록 예외 경로를 추가했습니다.
- 내부 캐시(`_active_links`)에 저장하는 키를 일관된 `link_name` 변수로 통일했습니다.
- 관련 단위 테스트를 보강/추가하여 기존 캐시 동작, 기존 링크 재사용 경로, `FileExistsError` 처리 경로를 검증하도록 `test_smb_manager.py`를 수정했습니다.

### Testing
- `poetry run python -m compileall app` 실행: 성공.
- `poetry run ruff check .` 실행: 성공 (모든 린트 통과).
- 전체 테스트 실행 `poetry run pytest -q` 실행: 실패 (3 tests failed in `test_folder_monitor_scan.py` due to missing `FolderMonitor` helper methods; 이는 이번 PR의 `smb_manager` 변경과 직접 관련 없는 기존 테스트 실패입니다).
- 변경 대상 단위 테스트만 실행 `poetry run pytest -q test_smb_manager.py` 실행: 성공 (11 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0b8bb5fc832c83842507cfedc086)