### PR TITLE
🧹 Clean up legacy urllib3 retry logic in ProxmoxAPI

### DIFF
--- a/app/proxmox_api.py
+++ b/app/proxmox_api.py
@@ -14,23 +14,13 @@ class ProxmoxAPI:
         self.session.verify = False
 
         # 재시도 로직 설정 (총 3회, 1초 대기)
-        try:
-            # urllib3 >= 1.26.0
-            retry_strategy = Retry(
-                total=3,
-                backoff_factor=1,
-                status_forcelist=[500, 502, 503, 504],
-                allowed_methods=["HEAD", "GET", "OPTIONS", "POST"]
-            )
-        except TypeError:
-            # urllib3 < 1.26.0
-            logging.warning("Detected older urllib3 version, falling back to method_whitelist")
-            retry_strategy = Retry(
-                total=3,
-                backoff_factor=1,
-                status_forcelist=[500, 502, 503, 504],
-                method_whitelist=["HEAD", "GET", "OPTIONS", "POST"]
-            )
+        # urllib3 >= 1.26.0 required
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["HEAD", "GET", "OPTIONS", "POST"]
+        )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed legacy `urllib3` retry logic from `app/proxmox_api.py`. Specifically, removed the `try-except TypeError` block that attempted to initialize `Retry` with `allowed_methods` and fell back to `method_whitelist` for older versions. The code now directly uses `allowed_methods`.

💡 **Why:** How this improves maintainability
The project's dependencies (verified via `poetry.lock`) ensure `urllib3 >= 1.26.0` (specifically 1.26.20), which supports `allowed_methods`. The fallback code for older versions was dead code that added unnecessary complexity and potential confusion. Removing it makes the initialization cleaner and more standard.

✅ **Verification:** How you confirmed the change is safe
1.  Created a temporary verification script `verify_proxmox_retry.py` that mocked `urllib3` and `requests`.
2.  Verified that `ProxmoxAPI` successfully initializes using `allowed_methods` with the refactored code.
3.  Ran existing tests (`test_smb_manager.py`, `test_transcoder.py`, and `test_folder_monitor_scan.py`) to ensure no regressions were introduced.
4.  Verified that `poetry.lock` confirms `urllib3` version `1.26.20`, which supports the used parameter.

✨ **Result:** The improvement achieved
`ProxmoxAPI` initialization is now cleaner, uses modern `urllib3` practices, and is free of dead fallback code.

---
*PR created automatically by Jules for task [6253503373888572334](https://jules.google.com/task/6253503373888572334) started by @wooooooooooook*