### PR TITLE
Fix transcoding settings display on main and settings pages

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -1682,6 +1682,7 @@ function renderTranscodingRules() {
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-gray-700">
                     <div><span class="text-gray-500">폴더 패턴:</span> ${escapeHtml(rule.folder_pattern || '-')}</div>
                     <div><span class="text-gray-500">파일 확장자:</span> ${escapeHtml(extensions || '-')}</div>
+                    <div><span class="text-gray-500">원본 삭제:</span> ${rule.delete_original !== false ? '예' : '아니오'}</div>
                     <div class="md:col-span-2"><span class="text-gray-500">FFmpeg 옵션:</span> <code class="text-[11px]">${escapeHtml(rule.ffmpeg_options || '-')}</code></div>
                     <div class="md:col-span-2"><span class="text-gray-500">출력 패턴:</span> ${escapeHtml(rule.output_pattern || '{{filename}}.transcoded.{{ext}}')}</div>
                 </div>
@@ -1938,4 +1939,9 @@ function toggleFeature(feature, enabled) {
     .finally(() => {
         if (checkbox) checkbox.disabled = false;
     });
+}
+
+function escapeHtml(text) {
+    const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
+    return String(text || '').replace(/[&<>"']/g, m => map[m]);
 }

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -906,7 +906,13 @@
                         <div class="form-group col-md-3 mb-1"><label class="small mb-1">출력 패턴</label><input class="form-control form-control-sm" value="${escapeHtml(rule.output_pattern || '{{filename}}.transcoded.{{ext}}')}" onchange="updateRule(${index}, 'output_pattern', this.value)"></div>
                     </div>
                     <div class="form-row align-items-end">
-                        <div class="form-group col-md-10 mb-1"><label class="small mb-1">FFmpeg 옵션</label><input class="form-control form-control-sm" value="${escapeHtml(rule.ffmpeg_options || '')}" onchange="updateRule(${index}, 'ffmpeg_options', this.value)"></div>
+                        <div class="form-group col-md-8 mb-1"><label class="small mb-1">FFmpeg 옵션</label><input class="form-control form-control-sm" value="${escapeHtml(rule.ffmpeg_options || '')}" onchange="updateRule(${index}, 'ffmpeg_options', this.value)"></div>
+                        <div class="form-group col-md-2 mb-1">
+                            <div class="custom-control custom-checkbox">
+                                <input type="checkbox" class="custom-control-input" id="deleteOriginal${index}" ${rule.delete_original !== false ? 'checked' : ''} onchange="updateRule(${index}, 'delete_original', this.checked)">
+                                <label class="custom-control-label small" for="deleteOriginal${index}">원본 삭제</label>
+                            </div>
+                        </div>
                         <div class="form-group col-md-2 mb-1 text-right"><button type="button" class="btn btn-sm btn-outline-danger" onclick="removeTranscodingRule(${index})">삭제</button></div>
                     </div>
                 </div></div>`;
@@ -924,7 +930,7 @@
         }
 
         function addTranscodingRule() {
-            transcodingRules.push({ name: `규칙 ${transcodingRules.length + 1}`, folder_pattern: '', file_extensions: ['mp4'], ffmpeg_options: '-c:v copy -c:a aac', output_pattern: '{{filename}}.transcoded.{{ext}}' });
+            transcodingRules.push({ name: `규칙 ${transcodingRules.length + 1}`, folder_pattern: '', file_extensions: ['mp4'], ffmpeg_options: '-c:v copy -c:a aac', delete_original: true, output_pattern: '{{filename}}.transcoded.{{ext}}' });
             renderTranscodingRules();
             saveTranscodingConfig();
         }


### PR DESCRIPTION
Fixes an issue where the main screen did not render configured transcoding settings due to a missing function (`escapeHtml`). Additionally, restores the "delete original file" (원본 삭제) option to the settings form and ensures it is displayed correctly on the main dashboard.

---
*PR created automatically by Jules for task [1898538895357321338](https://jules.google.com/task/1898538895357321338) started by @wooooooooooook*