### PR TITLE
feat(proxmox): Send qm stop 15s after shutdown webhook

### DIFF
--- a/app/proxmox_api.py
+++ b/app/proxmox_api.py
@@ -99,3 +99,13 @@ class ProxmoxAPI:
         except Exception as e:
             logging.error(f"VM 시작 API 호출 실패: {e}")
             return False
+
+
+    def stop_vm(self) -> bool:
+        try:
+            self._request("POST", "status/stop")
+            logging.debug("VM 중지 응답 받음")
+            return True
+        except Exception as e:
+            logging.error(f"VM 중지 API 호출 실패: {e}")
+            return False


### PR DESCRIPTION
Added `stop_vm` method to `ProxmoxAPI` using the `status/stop` endpoint. Updated `_send_shutdown_webhook` in `GShareManager` to start a background daemon thread that waits 15 seconds before invoking `stop_vm()`. This ensures the Proxmox VM receives a formal stop command shortly after the shutdown webhook is triggered.

---
*PR created automatically by Jules for task [17583959966543851327](https://jules.google.com/task/17583959966543851327) started by @wooooooooooook*