### PR TITLE
fix: shutdown_vm 엔드포인트를 메인 종료 플로우로 통합

### DIFF
--- a/app/web_server.py
+++ b/app/web_server.py
@@ -779,9 +779,8 @@ class GshareWebServer:
             if not self.manager.current_state.vm_running:
                 return jsonify({"status": "error", "message": "VM이 이미 종료되어 있습니다."}), 400
 
-            response = requests.post(
-                self.config.SHUTDOWN_WEBHOOK_URL, timeout=5)
-            response.raise_for_status()
+            # 메인 루프와 동일한 종료 플로우(웹훅 전송 + 예약 stop)를 재사용
+            self.manager._send_shutdown_webhook()
             return jsonify({"status": "success", "message": "VM 종료가 요청되었습니다."})
         except Exception as e:
             return jsonify({"status": "error", "message": f"VM 종료 요청 실패: {str(e)}"}), 500


### PR DESCRIPTION
### Motivation
- 수동으로 호출되는 `/shutdown_vm`이 직접 외부 웹훅만 호출하여 Proxmox에서 VM stop이 수신되지 않는 경우를 줄이고자 메인 루프의 종료 플로우와 동일하게 동작하도록 통합했습니다.

### Description
- `app/web_server.py`의 `shutdown_vm` 경로에서 직접 `requests.post(self.config.SHUTDOWN_WEBHOOK_URL)`를 호출하던 부분을 제거하고 메인 로직의 종료 처리 함수인 `self.manager._send_shutdown_webhook()`를 호출하도록 변경하여 웹훅 전송과 `pending_stop_at` 기반의 예약된 Proxmox stop 처리를 재사용하도록 했습니다.

### Testing
- `python -m compileall app`를 실행하여 바이트컴파일이 성공함을 확인했습니다 (성공). 
- `poetry check`를 실행했으며 Poetry 메타데이터 관련 경고만 보고되었습니다 (경고). 
- `pytest -q`를 실행했고 기존 `test_transcoder.py`의 2건이 실패하여 전체 테스트는 일부 실패로 종료되었으나 해당 실패는 이번 변경과 직접 관련이 없는 기존 테스트 이슈로 판단됩니다 (2 failed, 19 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3918ea49c832c80c0db446c22d257)