### PR TITLE
설정 페이지 CPU 임계치 입력 및 폼 검증 오류 수정

### DIFF
--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -284,7 +284,7 @@
                         <h3>VM 모니터링 설정</h3>
                         <div class="form-group">
                             <label for="cpu_threshold">CPU 사용량 임계치(%)</label>
-                            <input type="number" class="form-control" id="cpu_threshold" name="CPU_THRESHOLD" required value="{{ form_data.get('CPU_THRESHOLD', 10) }}" min="1" max="100">
+                            <input type="number" class="form-control" id="cpu_threshold" name="CPU_THRESHOLD" required value="{{ form_data.get('CPU_THRESHOLD', 10) }}" min="0" max="100" step="0.1">
                             <small class="form-text text-muted">이 값 이하로 CPU 사용량이 떨어지면 VM을 종료합니다.</small>
                         </div>
                         <div class="form-group">
@@ -501,6 +501,18 @@
         document.getElementById('setup-form').addEventListener('submit', async function(e) {
             e.preventDefault(); // 항상 먼저 제출을 방지
             saveTranscodingConfig();
+
+            const firstInvalidField = this.querySelector(':invalid');
+            if (firstInvalidField) {
+                const pane = firstInvalidField.closest('.tab-pane');
+                if (pane) {
+                    $('#setupTabs a[href="#' + pane.id + '"]').tab('show');
+                    updateProgressBar(pane.id + '-tab');
+                }
+                firstInvalidField.reportValidity();
+                firstInvalidField.focus();
+                return;
+            }
             
             const requiredFields = document.querySelectorAll('input[required]');
             let allValid = true;


### PR DESCRIPTION
### Motivation
- 설정 화면에서 `CPU_THRESHOLD`에 소수값(예: 2.5)을 입력할 수 없고 제출 시 `invalid form control with name='CPU_THRESHOLD' is not focusable` 오류가 발생하는 문제를 해결하기 위함입니다.

### Description
- `app/templates/landing.html`의 `CPU_THRESHOLD` 입력 필드에 `min="0"`과 `step="0.1"`을 추가해 소수 입력이 HTML5 유효성 검사에서 차단되지 않도록 변경했습니다.
- 폼 제출 핸들러에 `:invalid` 필드를 먼저 찾아 해당 필드가 숨겨진 탭에 있으면 그 탭을 활성화한 뒤 `reportValidity()`와 `focus()`를 호출해 사용자에게 올바른 탭에서 유효성 오류를 즉시 안내하도록 보완했습니다.
- 변경 내용은 템플릿(`app/templates/landing.html`)에만 적용되었습니다.

### Testing
- `python -m compileall app`는 성공했습니다.
- `ruff check .`는 저장소의 기존 테스트 파일(`test_folder_monitor_scan.py`)에서의 E402 lint 문제로 실패했으며 이는 본 변경과 무관합니다.
- `pytest -q` 실행 시 기존의 `test_transcoder.py` 관련 테스트 2건이 실패했으며 이 실패는 이번 프론트엔드 변경과 관련이 없습니다.
- Playwright를 이용해 `http://127.0.0.1:5000/settings`로 스크린샷을 시도했으나 `ERR_EMPTY_RESPONSE`로 연결되지 않아 캡처는 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e662ef1c832c8ef53490270190ec)