### PR TITLE
perf: 대시보드 폴더 렌더링 최적화 및 상태 디버그 로그 제어

### DIFF
--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -90,9 +90,15 @@ let userScrolled = false; // userScrolled 변수를 전역 변수로 이동
 let monitorMode = 'event';
 let initialScanInProgress = false;
 let hasReceivedStateUpdate = false;
+let lastFolderRenderSignature = '';
+const ENABLE_STATE_DEBUG_LOG = false;
 
 // state를 콘솔에 로깅하는 함수
 function logStateToConsole(state) {
+    if (!ENABLE_STATE_DEBUG_LOG) {
+        return;
+    }
+
     console.log('=== State 업데이트 ===');
     console.log(state)
     // 마운트된 폴더 갯수 출력
@@ -1178,6 +1184,7 @@ function updateFolderList(sortedFolders) {
 
     // 폴더 목록이 비어있는 경우
     if (!sortedFolders || sortedFolders.length === 0) {
+        lastFolderRenderSignature = 'EMPTY';
         document.getElementById('monitoredFoldersContainer').innerHTML = `
             <div class="text-center py-4">
                 <p class="text-sm text-gray-600">감시 중인 폴더가 없습니다.</p>
@@ -1196,6 +1203,21 @@ function updateFolderList(sortedFolders) {
         }
         return;
     }
+
+    // 폴더 마운트 상태가 직전 렌더링과 동일하면 DOM 업데이트를 생략
+    const nextRenderSignature = sortedFolders
+        .map(([folderName, folder]) => `${folderName}:${folder.is_mounted ? 1 : 0}`)
+        .join('|');
+
+    if (nextRenderSignature === lastFolderRenderSignature) {
+        const statusIndicator = document.querySelector('.status-update-indicator');
+        if (statusIndicator) {
+            statusIndicator.classList.add('hidden');
+        }
+        return;
+    }
+
+    lastFolderRenderSignature = nextRenderSignature;
 
     // 로딩 요소 숨기기
     const loadingElement = document.getElementById('loadingFolders');
@@ -1233,8 +1255,10 @@ function updateFolderList(sortedFolders) {
     unmountedFolders.length = unmountedCount;
     mountedFolders.length = mountedCount;
 
-    console.log('마운트되지 않은 폴더 갯수:', unmountedCount);
-    console.log('마운트된 폴더 갯수:', mountedCount);
+    if (ENABLE_STATE_DEBUG_LOG) {
+        console.log('마운트되지 않은 폴더 갯수:', unmountedCount);
+        console.log('마운트된 폴더 갯수:', mountedCount);
+    }
 
     // 총 폴더 수가 많은 경우 비동기 처리 최적화
     const isBatchProcessingNeeded = sortedFolders.length > 200;


### PR DESCRIPTION
### Motivation
- 대시보드에서 주기적으로 수신되는 상태로 인해 동일한 폴더 목록을 반복적으로 DOM에 다시 그려 `setInterval`/message 핸들러 지연 및 forced reflow 경고가 발생하므로 이를 완화하려는 목적입니다.
- 상태 전체를 매번 콘솔에 출력해 스팸성 로그가 쌓이는 문제를 기본적으로 비활성화하여 개발자 콘솔 노이즈를 줄이려는 의도입니다.

### Description
- `app/static/scripts.js`에 `lastFolderRenderSignature` 변수를 추가해 마지막 렌더 상태 서명을 저장하도록 했습니다.
- `ENABLE_STATE_DEBUG_LOG` 플래그를 추가하고 `logStateToConsole`에서 기본적으로 로그 출력을 차단하도록 변경했습니다.
- `updateFolderList` 내에서 `nextRenderSignature`를 계산해 이전 서명과 동일할 경우 DOM 업데이트(및 컨테이너 재생성)를 건너뛰도록 짧은 회로(short-circuit) 로직을 추가했습니다.
- 상태 표시기(`.status-update-indicator`) 동작은 유지하되 렌더 스킵 시 숨기도록 처리했고, 디버그 로깅 호출을 `ENABLE_STATE_DEBUG_LOG`로 감쌌습니다.

### Testing
- `python -m compileall app`를 실행해 컴파일 오류가 없는 것을 확인했습니다 (성공). 
- `poetry check`를 실행해 구성 관련 deprecation 경고 외에는 체크를 통과했음을 확인했습니다 (성공, 경고 출력 존재).
- `pytest -q`를 실행했으며 기존 테스트 중 `test_transcoder.py`의 두 케이스(`test_load_done_list_caching`, `test_iter_walk_matches_optimization`)가 실패하여 전체 테스트는 실패했습니다 (실패: 2, 통과: 19).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e7be5b54832ca1d48c6131a61ea1)