### PR TITLE
feat: Add Android VM Image Upload and Viewer

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,8 @@ class GshareConfig:
     NODE_NAME: str
     ## android VM ID
     VM_ID: str
+    ## android VM IP
+    ANDROID_VM_IP: str
     ## API 연결 타임아웃(초)
     PROXMOX_TIMEOUT: int
     ## API 토큰 ID
@@ -172,6 +174,7 @@ class GshareConfig:
             'PROXMOX_HOST': yaml_config['credentials'].get('proxmox_host', ''),
             'NODE_NAME': yaml_config['proxmox'].get('node_name', ''),
             'VM_ID': yaml_config['proxmox'].get('vm_id', ''),
+            'ANDROID_VM_IP': yaml_config['proxmox'].get('android_vm_ip', ''),
             'PROXMOX_TIMEOUT': yaml_config['proxmox'].get('timeout') or 5,
             'TOKEN_ID': yaml_config['credentials'].get('token_id', ''),
             'SECRET': yaml_config['credentials'].get('secret', ''),
@@ -271,6 +274,8 @@ class GshareConfig:
             yaml_config['proxmox']['node_name'] = config_dict['NODE_NAME']
         if "VM_ID" in config_dict:
             yaml_config["proxmox"]["vm_id"] = config_dict["VM_ID"]
+        if "ANDROID_VM_IP" in config_dict:
+            yaml_config["proxmox"]["android_vm_ip"] = config_dict["ANDROID_VM_IP"]
         if "PROXMOX_TIMEOUT" in config_dict and str(config_dict["PROXMOX_TIMEOUT"]).strip():
             yaml_config["proxmox"]["timeout"] = int(config_dict["PROXMOX_TIMEOUT"])
         if 'CPU_THRESHOLD' in config_dict and str(config_dict['CPU_THRESHOLD']).strip():
@@ -404,7 +409,7 @@ class GshareConfig:
         
         # 템플릿 파일이 없으면 기본 설정 반환
         return {
-            'proxmox': {'node_name': '', 'vm_id': '', 'timeout': 5, 'cpu': {'threshold': 10.0, 'check_interval': 60, 'threshold_count': 3}},
+            'proxmox': {'node_name': '', 'vm_id': '', 'android_vm_ip': '', 'timeout': 5, 'cpu': {'threshold': 10.0, 'check_interval': 60, 'threshold_count': 3}},
             'mount': {'path': '/mnt/gshare', 'folder_size_timeout': 30},
             'smb': {'share_name': 'gshare', 'comment': 'GShare SMB 공유', 'guest_ok': False, 'read_only': True, 'links_dir': '/mnt/gshare_links', 'port': 445},
             'nfs': {'path': ''},

--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -1970,3 +1970,79 @@ function escapeHtml(text) {
     const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
     return String(text || '').replace(/[&<>"']/g, m => map[m]);
 }
+
+// 이미지 뷰어 관련 로직
+let currentImageList = [];
+let currentImageIndex = 0;
+
+function fetchImages() {
+    fetch('/api/images')
+        .then(response => response.json())
+        .then(data => {
+            if (data.status === 'success') {
+                currentImageList = data.images;
+                updateImageViewer();
+            } else {
+                console.error('이미지 목록 로드 실패:', data.message);
+            }
+        })
+        .catch(error => {
+            console.error('이미지 API 호출 중 오류 발생:', error);
+        });
+}
+
+function updateImageViewer() {
+    const container = document.getElementById('imageViewerContainer');
+    const noMsg = document.getElementById('noImagesMsg');
+    const imgEl = document.getElementById('currentImage');
+    const timeEl = document.getElementById('imageTime');
+    const counterEl = document.getElementById('imageCounter');
+    const prevBtn = document.getElementById('prevImageBtn');
+    const nextBtn = document.getElementById('nextImageBtn');
+
+    if (!currentImageList || currentImageList.length === 0) {
+        container.classList.add('hidden');
+        noMsg.classList.remove('hidden');
+        counterEl.textContent = '0/0';
+        return;
+    }
+
+    container.classList.remove('hidden');
+    noMsg.classList.add('hidden');
+
+    // 현재 인덱스 유효성 검사
+    if (currentImageIndex < 0) currentImageIndex = 0;
+    if (currentImageIndex >= currentImageList.length) currentImageIndex = currentImageList.length - 1;
+
+    const currentData = currentImageList[currentImageIndex];
+
+    // 이미지 및 정보 업데이트
+    imgEl.src = currentData.url;
+    timeEl.textContent = currentData.time;
+    counterEl.textContent = `${currentImageIndex + 1}/${currentImageList.length}`;
+
+    // 버튼 상태 업데이트 (최신이 인덱스 0)
+    prevBtn.disabled = currentImageIndex >= currentImageList.length - 1; // 과거로 이동
+    nextBtn.disabled = currentImageIndex <= 0; // 최신으로 이동
+}
+
+function showPrevImage() {
+    if (currentImageIndex < currentImageList.length - 1) {
+        currentImageIndex++;
+        updateImageViewer();
+    }
+}
+
+function showNextImage() {
+    if (currentImageIndex > 0) {
+        currentImageIndex--;
+        updateImageViewer();
+    }
+}
+
+// 초기화 시 이미지 로드
+document.addEventListener('DOMContentLoaded', function() {
+    fetchImages();
+    // 30초마다 이미지 갱신
+    setInterval(fetchImages, 30000);
+});

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -470,6 +470,44 @@
 			</div>
 		</div>
 
+
+		<!-- 이미지 뷰어 패널 -->
+		<div class="bg-white rounded-lg shadow-sm mb-4 border border-gray-200 p-4">
+			<div class="flex items-center justify-between mb-3">
+				<div class="flex items-center gap-2">
+					<svg class="w-5 h-5 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+					</svg>
+					<h3 class="text-sm font-bold text-gray-800">최근 수신된 이미지</h3>
+				</div>
+                <div class="text-xs text-gray-500">
+                    <span id="imageCounter">0/0</span>
+                </div>
+			</div>
+
+			<div id="imageViewerContainer" class="hidden">
+				<div class="flex justify-center mb-2 bg-gray-50 rounded-lg border border-gray-200 overflow-hidden" style="min-height: 200px; max-height: 60vh;">
+					<img id="currentImage" src="" alt="수신된 이미지" class="object-contain w-full h-full max-h-[60vh]">
+				</div>
+
+				<div class="flex justify-between items-center mt-3">
+					<button id="prevImageBtn" onclick="showPrevImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
+						&lt; 이전
+					</button>
+					<div class="text-sm font-medium text-gray-700">
+						수신 시각: <span id="imageTime" class="text-blue-600"></span>
+					</div>
+					<button id="nextImageBtn" onclick="showNextImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
+						다음 &gt;
+					</button>
+				</div>
+			</div>
+
+			<div id="noImagesMsg" class="text-center py-8 text-sm text-gray-400">
+				저장된 이미지가 없습니다.
+			</div>
+		</div>
+
 		<!-- 로그 패널 -->
 		<div class="bg-white rounded-lg shadow-sm p-4 mb-4 border border-gray-200">
 			<div class="flex items-center justify-between mb-2">

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -180,6 +180,11 @@
                             <input type="text" class="form-control" id="vm_id" name="VM_ID" required placeholder="100" value="{{ form_data.get('VM_ID', '') }}">
                         </div>
                         <div class="form-group">
+                            <label for="android_vm_ip">Android VM IP</label>
+                            <input type="text" class="form-control" id="android_vm_ip" name="ANDROID_VM_IP" required placeholder="192.168.1.50" value="{{ form_data.get('ANDROID_VM_IP', '') }}">
+                            <small class="form-text text-muted">안드로이드 VM의 내부 IP 주소를 입력하세요.</small>
+                        </div>
+                        <div class="form-group">
                             <label for="proxmox_timeout">API 연결 타임아웃 (초)</label>
                             <input type="number" class="form-control" id="proxmox_timeout" name="PROXMOX_TIMEOUT" value="{{ form_data.get('PROXMOX_TIMEOUT', 5) }}" min="1" required>
                             <small class="form-text text-muted">기본값: 5초. 네트워크가 느릴 경우 늘려주세요.</small>

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -234,8 +234,10 @@ class GshareWebServer:
                               self.update_config, methods=['POST'])
         self.app.add_url_rule('/api/folder-event', 'folder_event',
                               self.folder_event, methods=['POST'])
-        self.app.add_url_rule(
-            '/test_proxmox_api', 'test_proxmox_api', self.test_proxmox_api, methods=['POST'])
+        self.app.add_url_rule('/api/images', 'get_images', self.get_images, methods=['GET'])
+        self.app.add_url_rule('/api/upload_image', 'upload_image',
+                              self.upload_image, methods=['POST'])
+        self.app.add_url_rule('/test_proxmox_api', 'test_proxmox_api', self.test_proxmox_api, methods=['POST'])
         self.app.add_url_rule('/test_nfs', 'test_nfs',
                               self.test_nfs, methods=['POST'])
         self.app.add_url_rule('/test_mqtt', 'test_mqtt',
@@ -372,6 +374,7 @@ class GshareWebServer:
             'PROXMOX_HOST': creds.get('proxmox_host', ''),
             'NODE_NAME': proxmox.get('node_name', ''),
             'VM_ID': proxmox.get('vm_id', ''),
+            'ANDROID_VM_IP': proxmox.get('android_vm_ip', ''),
             'PROXMOX_TIMEOUT': proxmox.get('timeout', 5),
             'CPU_THRESHOLD': proxmox_cpu.get('threshold', 10),
             'CHECK_INTERVAL': proxmox_cpu.get('check_interval', 60),
@@ -469,6 +472,7 @@ class GshareWebServer:
                 'PROXMOX_HOST': form_data.get('PROXMOX_HOST', ''),
                 'NODE_NAME': form_data.get('NODE_NAME', ''),
                 'VM_ID': form_data.get('VM_ID', ''),
+                'ANDROID_VM_IP': form_data.get('ANDROID_VM_IP', ''),
                 'PROXMOX_TIMEOUT': form_data.get('PROXMOX_TIMEOUT', 5),
                 'TOKEN_ID': form_data.get('TOKEN_ID', ''),
                 'SECRET': form_data.get('SECRET', ''),
@@ -1142,6 +1146,107 @@ class GshareWebServer:
             return jsonify({'phase': 'idle', 'is_processing': False})
         except Exception as e:
             return jsonify({'phase': 'idle', 'is_processing': False, 'error': str(e)})
+
+    def get_images(self):
+        """저장된 이미지 목록 제공 API"""
+        try:
+            image_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'images')
+            if not os.path.exists(image_dir):
+                return jsonify({"status": "success", "images": []}), 200
+
+            allowed_extensions = {'.png', '.jpg', '.jpeg'}
+            images = []
+
+            for f in os.listdir(image_dir):
+                if f.startswith('image_') and any(f.endswith(e) for e in allowed_extensions):
+                    # 파일명 형식: image_YYYYMMDD_HHMMSS_ffffff.ext
+                    # 파싱하여 수신 시각 생성
+                    try:
+                        time_str = f[6:21] # YYYYMMDD_HHMMSS 부분 추출
+                        dt = datetime.strptime(time_str, "%Y%m%d_%H%M%S")
+                        formatted_time = dt.strftime("%Y-%m-%d %H:%M:%S")
+                    except ValueError:
+                        formatted_time = "알 수 없음"
+
+                    images.append({
+                        "filename": f,
+                        "url": url_for('static', filename=f'images/{f}'),
+                        "time": formatted_time
+                    })
+
+            # 최신 이미지가 먼저 오도록 정렬 (파일명 기준 역순)
+            images.sort(key=lambda x: x['filename'], reverse=True)
+
+            return jsonify({"status": "success", "images": images}), 200
+
+        except Exception as e:
+            logging.error(f"이미지 목록 조회 중 오류 발생: {e}")
+            return jsonify({"status": "error", "message": str(e)}), 500
+
+    def upload_image(self):
+        """이미지 업로드 API"""
+        try:
+            # 설정 확인
+            if self.config is None:
+                return jsonify({"status": "error", "message": "서버가 아직 초기화되지 않았습니다."}), 503
+
+            android_ip = getattr(self.config, 'ANDROID_VM_IP', '')
+            client_ip = request.remote_addr
+
+            # IP 검증
+            if not android_ip or client_ip != android_ip:
+                logging.warning(f"허용되지 않은 IP에서의 이미지 업로드 시도: {client_ip} (허용된 IP: {android_ip})")
+                return jsonify({"status": "error", "message": "접근이 거부되었습니다."}), 403
+
+            # 파일 확인
+            if 'image' not in request.files:
+                return jsonify({"status": "error", "message": "이미지 파일이 제공되지 않았습니다."}), 400
+
+            file = request.files['image']
+            if file.filename == '':
+                return jsonify({"status": "error", "message": "선택된 파일이 없습니다."}), 400
+
+            # 확장자 검증
+            allowed_extensions = {'.png', '.jpg', '.jpeg'}
+            ext = os.path.splitext(file.filename)[1].lower()
+            if ext not in allowed_extensions:
+                return jsonify({"status": "error", "message": "PNG, JPG 형식만 지원합니다."}), 400
+
+            # 저장 디렉토리 설정
+            image_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'images')
+            os.makedirs(image_dir, exist_ok=True)
+
+            # 파일명 생성 (타임스탬프)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            filename = f"image_{timestamp}{ext}"
+            filepath = os.path.join(image_dir, filename)
+
+            # 파일 저장
+            file.save(filepath)
+
+            # 오래된 파일 삭제 (100개 유지)
+            files = []
+            for f in os.listdir(image_dir):
+                if f.startswith('image_') and any(f.endswith(e) for e in allowed_extensions):
+                    files.append(os.path.join(image_dir, f))
+
+            # 오래된 순으로 정렬 (수정 시간 또는 파일명 기준, 파일명이 타임스탬프이므로 파일명 기준 정렬)
+            files.sort()
+
+            while len(files) > 100:
+                oldest_file = files.pop(0)
+                try:
+                    os.remove(oldest_file)
+                    logging.debug(f"오래된 이미지 삭제됨: {oldest_file}")
+                except Exception as e:
+                    logging.error(f"오래된 이미지 삭제 실패: {e}")
+
+            return jsonify({"status": "success", "message": "이미지가 성공적으로 업로드되었습니다.", "filename": filename}), 200
+
+        except Exception as e:
+            logging.error(f"이미지 업로드 처리 중 오류 발생: {e}")
+            logging.error(traceback.format_exc())
+            return jsonify({"status": "error", "message": str(e)}), 500
 
     def test_proxmox_api(self):
         """Proxmox API 연결 테스트"""


### PR DESCRIPTION
Implemented the feature to receive images from a configured Android VM IP address and display the latest 100 images on the main dashboard.

1.  **Configuration**: Added `ANDROID_VM_IP` to `GshareConfig` in `app/config.py` and updated the setup wizard (`app/templates/landing.html`) and backend config loading/saving (`app/web_server.py`) to manage it.
2.  **API Endpoints**: 
    *   `/api/upload_image` (POST): Validates the client IP against `ANDROID_VM_IP`, accepts `.png` and `.jpg` files, saves them with a timestamp, and manages the directory to keep only the latest 100 files.
    *   `/api/images` (GET): Returns a list of saved images with their URLs and formatted receipt times.
3.  **UI**: 
    *   Added an image viewer panel to `app/templates/index.html` displaying the current image, a counter, the receipt time, and previous/next navigation buttons.
    *   Implemented logic in `app/static/scripts.js` to asynchronously fetch images, update the UI, handle pagination, and auto-refresh the list every 30 seconds.

---
*PR created automatically by Jules for task [2743349071365796533](https://jules.google.com/task/2743349071365796533) started by @wooooooooooook*