### PR TITLE
style: move Android VM IP to VM tab and relocate Image Viewer

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -403,6 +403,45 @@
 							</span>
 						</div>
 					</div>
+
+
+
+		<!-- 이미지 뷰어 패널 -->
+		<div class="mt-4 border-t border-gray-200 pt-4">
+			<div class="flex items-center justify-between mb-3">
+				<div class="flex items-center gap-2">
+					<svg class="w-5 h-5 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+					</svg>
+					<h3 class="text-sm font-bold text-gray-800">최근 수신된 이미지</h3>
+				</div>
+                <div class="text-xs text-gray-500">
+                    <span id="imageCounter">0/0</span>
+                </div>
+			</div>
+
+			<div id="imageViewerContainer" class="hidden">
+				<div class="flex justify-center mb-2 bg-gray-50 rounded-lg border border-gray-200 overflow-hidden" style="min-height: 200px; max-height: 60vh;">
+					<img id="currentImage" src="" alt="수신된 이미지" class="object-contain w-full h-full max-h-[60vh]">
+				</div>
+
+				<div class="flex justify-between items-center mt-3">
+					<button id="prevImageBtn" onclick="showPrevImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
+						&lt; 이전
+					</button>
+					<div class="text-sm font-medium text-gray-700">
+						수신 시각: <span id="imageTime" class="text-blue-600"></span>
+					</div>
+					<button id="nextImageBtn" onclick="showNextImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
+						다음 &gt;
+					</button>
+				</div>
+			</div>
+
+			<div id="noImagesMsg" class="text-center py-8 text-sm text-gray-400">
+				저장된 이미지가 없습니다.
+			</div>
+		</div>
 				</div>
 			</div>
 		</div>
@@ -467,44 +506,6 @@
 							</div>
 						</div>
 					</div>
-			</div>
-		</div>
-
-
-		<!-- 이미지 뷰어 패널 -->
-		<div class="bg-white rounded-lg shadow-sm mb-4 border border-gray-200 p-4">
-			<div class="flex items-center justify-between mb-3">
-				<div class="flex items-center gap-2">
-					<svg class="w-5 h-5 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-					</svg>
-					<h3 class="text-sm font-bold text-gray-800">최근 수신된 이미지</h3>
-				</div>
-                <div class="text-xs text-gray-500">
-                    <span id="imageCounter">0/0</span>
-                </div>
-			</div>
-
-			<div id="imageViewerContainer" class="hidden">
-				<div class="flex justify-center mb-2 bg-gray-50 rounded-lg border border-gray-200 overflow-hidden" style="min-height: 200px; max-height: 60vh;">
-					<img id="currentImage" src="" alt="수신된 이미지" class="object-contain w-full h-full max-h-[60vh]">
-				</div>
-
-				<div class="flex justify-between items-center mt-3">
-					<button id="prevImageBtn" onclick="showPrevImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
-						&lt; 이전
-					</button>
-					<div class="text-sm font-medium text-gray-700">
-						수신 시각: <span id="imageTime" class="text-blue-600"></span>
-					</div>
-					<button id="nextImageBtn" onclick="showNextImage()" class="text-xs px-3 py-1.5 bg-gray-50 hover:bg-gray-100 text-gray-700 rounded border border-gray-200 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed">
-						다음 &gt;
-					</button>
-				</div>
-			</div>
-
-			<div id="noImagesMsg" class="text-center py-8 text-sm text-gray-400">
-				저장된 이미지가 없습니다.
 			</div>
 		</div>
 

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -180,11 +180,6 @@
                             <input type="text" class="form-control" id="vm_id" name="VM_ID" required placeholder="100" value="{{ form_data.get('VM_ID', '') }}">
                         </div>
                         <div class="form-group">
-                            <label for="android_vm_ip">Android VM IP</label>
-                            <input type="text" class="form-control" id="android_vm_ip" name="ANDROID_VM_IP" required placeholder="192.168.1.50" value="{{ form_data.get('ANDROID_VM_IP', '') }}">
-                            <small class="form-text text-muted">안드로이드 VM의 내부 IP 주소를 입력하세요.</small>
-                        </div>
-                        <div class="form-group">
                             <label for="proxmox_timeout">API 연결 타임아웃 (초)</label>
                             <input type="number" class="form-control" id="proxmox_timeout" name="PROXMOX_TIMEOUT" value="{{ form_data.get('PROXMOX_TIMEOUT', 5) }}" min="1" required>
                             <small class="form-text text-muted">기본값: 5초. 네트워크가 느릴 경우 늘려주세요.</small>
@@ -273,6 +268,11 @@
                 <div class="tab-pane fade" id="vm" role="tabpanel" aria-labelledby="vm-tab">
                     <div class="form-section">
                         <h3>VM 설정</h3>
+                        <div class="form-group">
+                            <label for="android_vm_ip">Android VM IP</label>
+                            <input type="text" class="form-control" id="android_vm_ip" name="ANDROID_VM_IP" required placeholder="192.168.1.50" value="{{ form_data.get('ANDROID_VM_IP', '') }}">
+                            <small class="form-text text-muted">안드로이드 VM의 내부 IP 주소를 입력하세요.</small>
+                        </div>
                         <div class="form-group">
                             <label for="shutdown_webhook">MacroDroid 종료 웹훅 URL</label>
                             <input type="text" class="form-control" id="shutdown_webhook" name="SHUTDOWN_WEBHOOK_URL" required placeholder="https://example.com/webhook" value="{{ form_data.get('SHUTDOWN_WEBHOOK_URL', '') }}">


### PR DESCRIPTION
- Moved the `Android VM IP` configuration field from the Proxmox API tab to the VM settings tab in `landing.html`.
- Relocated the "Received Image Viewer" (최근 수신된 이미지) panel from a standalone block to inside the Android VM status section in `index.html`.
- Adjusted border and margin CSS classes in the embedded Image Viewer to maintain a clean appearance within the new container.

---
*PR created automatically by Jules for task [18169588134730030845](https://jules.google.com/task/18169588134730030845) started by @wooooooooooook*