### PR TITLE
fix: start_vm 핸들러에서 실시간 VM 상태 확인

### DIFF
--- a/app/web_server.py
+++ b/app/web_server.py
@@ -766,7 +766,8 @@ class GshareWebServer:
             if self.manager is None:
                 return jsonify({"status": "error", "message": "서버가 아직 초기화되지 않았습니다."}), 404
 
-            if self.manager.current_state.vm_running:
+            vm_running = self.manager.proxmox_api.is_vm_running()
+            if vm_running:
                 return jsonify({"status": "error", "message": "VM이 이미 실행 중입니다."}), 400
 
             if self.manager.proxmox_api.start_vm():


### PR DESCRIPTION
### Motivation
- VM이 이미 실행 중인데도 캐시된 상태(`current_state.vm_running`)가 stale하여 중복으로 시작 명령이 전송되는 것을 방지하기 위해 요청 직전에 실시간 상태를 확인하도록 변경했습니다.

### Description
- `app/web_server.py`의 `start_vm()`에서 `self.manager.current_state.vm_running` 대신 `vm_running = self.manager.proxmox_api.is_vm_running()`로 실시간 상태를 조회해 이미 실행 중인 경우 시작 요청을 차단하도록 수정했습니다.

### Testing
- 자동화 검사로 `poetry check`를 실행했으며 성공했으나 일부 deprecation 경고가 출력되었습니다; `poetry run ruff check .`는 기존 테스트 파일의 import 순서(E402) 문제로 실패했고, `poetry run pytest`는 `test_transcoder.py`의 2개 테스트 실패를 포함해 2건 실패, 19건 통과로 종료했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065fa06954832ca4d605069705f0ca)